### PR TITLE
Support for aribitrary environment variables

### DIFF
--- a/charts/mozilla-common-voice/Chart.yaml
+++ b/charts/mozilla-common-voice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mozilla-common-voice
 icon: https://voice.mozilla.org/dist/f01895c77138837851f87c2e40acbd58.svg
-version: 0.1.10
+version: 0.1.11
 description: Deploy Mozilla Common Voice web application
 type: 
 keywords:

--- a/charts/mozilla-common-voice/templates/configmap.yaml
+++ b/charts/mozilla-common-voice/templates/configmap.yaml
@@ -21,3 +21,6 @@ data:
   CV_KIBANA_URL: "{{ .Values.voice_web.config.kibana.url }}"
   CV_KIBANA_PREFIX: "{{ .Values.voice_web.config.kibana.prefix }}"
   CV_LAST_DATASET: "{{ .Values.voice_web.config.last_dataset }}"
+{{- if .Values.voice_web.config.extra_vars }}
+      {{- toYaml .Values.voice_web.config.extra_vars | nindent 2 }}
+{{- end }}


### PR DESCRIPTION
This PR will allow users using this chart to add any arbitrary environment variable to their configmaps.

This allows for more flexible and fast configuration, because now users can define extra variables without having to modify the main chart.