### PR TITLE
Render String in configmap instead of array.

### DIFF
--- a/charts/mozilla-common-voice/Chart.yaml
+++ b/charts/mozilla-common-voice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: mozilla-common-voice
 icon: https://voice.mozilla.org/dist/f01895c77138837851f87c2e40acbd58.svg
-version: 0.1.13
+version: 0.1.14
 description: Deploy Mozilla Common Voice web application
 type: 
 keywords:

--- a/charts/mozilla-common-voice/templates/configmap.yaml
+++ b/charts/mozilla-common-voice/templates/configmap.yaml
@@ -15,11 +15,11 @@ data:
   CV_BUCKET_NAME: "{{ .Values.voice_web.config.s3.bucket_name }}"
   CV_BUCKET_LOCATION: "{{ .Values.voice_web.config.s3.location }}"
   CV_ENVIRONMENT: "{{ .Values.voice_web.config.environment }}"
-  CV_ADMIN_EMAILS: "{{ .Values.voice_web.config.admin_emails }}"
+  CV_ADMIN_EMAILS: {{ .Values.voice_web.config.admin_emails }}
   CV_REDIS_URL: "{{ .Values.voice_web.config.redis_url }}"
   CV_KIBANA_URL: "{{ .Values.voice_web.config.kibana.url }}"
   CV_KIBANA_PREFIX: "{{ .Values.voice_web.config.kibana.prefix }}"
-  CV_KIBANA_ADMINS: "{{ .Values.voice_web.config.kibana.admins }}"
+  CV_KIBANA_ADMINS: {{ .Values.voice_web.config.kibana.admins }}
   CV_LAST_DATASET: "{{ .Values.voice_web.config.last_dataset }}"
 {{- if .Values.voice_web.config.extra_vars }}
       {{- toYaml .Values.voice_web.config.extra_vars | nindent 2 }}


### PR DESCRIPTION
Previously, Helm was parsing the string adding an array to the configmap. However the app is expecting a string containing an array of strings