### PR TITLE
Fixing a typo Daemonsets != DaemonSet

### DIFF
--- a/charts/fluentd-papertrail/Chart.yaml
+++ b/charts/fluentd-papertrail/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd-papertrail
 description: A Helm chart to deploy fluentd to send to papertrail
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.2
 
 keywords:

--- a/charts/fluentd-papertrail/ci/ct-values.yaml
+++ b/charts/fluentd-papertrail/ci/ct-values.yaml
@@ -1,0 +1,3 @@
+clusterName: "test-cluster"
+secrets:
+  name: test-secret

--- a/charts/fluentd-papertrail/templates/clusterrolebinding.yaml
+++ b/charts/fluentd-papertrail/templates/clusterrolebinding.yaml
@@ -9,6 +9,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: {{ include "fluentd-papertrail.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/fluentd-papertrail/templates/daemonsets.yaml
+++ b/charts/fluentd-papertrail/templates/daemonsets.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Daemonsets
+kind: DaemonSet
 metadata:
   name: {{ include "fluentd-papertrail.fullname" . }}
   labels:

--- a/charts/fluentd-papertrail/templates/daemonsets.yaml
+++ b/charts/fluentd-papertrail/templates/daemonsets.yaml
@@ -30,6 +30,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            {{- if .Values.secrets.name }}
             - name: FLUENT_PAPERTRAIL_HOST
               valueFrom:
                 secretKeyRef:
@@ -40,6 +41,7 @@ spec:
                 secretKeyRef:
                   name: {{ template "fluentd-papertrail.secrets" . }}
                   key: FLUENT_PAPERTRAIL_PORT
+            {{- end }}
             - name: FLUENT_HOSTNAME
               value: {{ template "fluentd-papertrail.clusterName" . }}
             - name: K8S_NODE_NAME

--- a/charts/fluentd-papertrail/templates/tests/test-secrets.yaml
+++ b/charts/fluentd-papertrail/templates/tests/test-secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+type: Opaque
+data:
+  # These are just test values
+  FLUENT_PAPERTRAIL_HOST: ZXhhbXBsZS5jb20=
+  FLUENT_PAPERTRAIL_PORT: MTIzNA==

--- a/charts/fluentd-papertrail/values.yaml
+++ b/charts/fluentd-papertrail/values.yaml
@@ -22,8 +22,8 @@ rbac:
   create: true
 
 # name of kubernetes secrets to use
-secrets:
-  name:
+secrets: {}
+  # name: papertrail
 
 tolerations:
   - key: "node-role.kubernetes.io/master"

--- a/ci/ct.yaml
+++ b/ci/ct.yaml
@@ -1,5 +1,5 @@
 remote: origin
-helm-extra-args: --timeout 600
+helm-extra-args: --timeout 600s
 check-version-increment: true
 validate-yaml: true
 validate-chart-schema: false


### PR DESCRIPTION
Had a typo for the daemonset manifest so fixing it the correct name is `DaemonSet` instead of `Daemonsets`