### PR TITLE
[mozmoderator] Create Helm Chart for mozmoderator

### DIFF
--- a/charts/mozmoderator/.helmignore
+++ b/charts/mozmoderator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mozmoderator/Chart.yaml
+++ b/charts/mozmoderator/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: mozmoderator
+description: A Helm Chart for Mozilla's Moderator application
+type: application
+version: 0.1.0
+appVersion: c285426edacb3a1791bab84f64c16d00e6d865eb
+keywords:
+  - Mozilla
+  - moderator
+sources:
+  - https://github.com/mozilla/mozmoderator
+maintainers:
+  - name: Alberto del Barrio
+    email: alberto@mozilla.com

--- a/charts/mozmoderator/templates/NOTES.txt
+++ b/charts/mozmoderator/templates/NOTES.txt
@@ -1,0 +1,21 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mozmoderator.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mozmoderator.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mozmoderator.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mozmoderator.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/mozmoderator/templates/_helpers.tpl
+++ b/charts/mozmoderator/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mozmoderator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mozmoderator.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mozmoderator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "mozmoderator.labels" -}}
+helm.sh/chart: {{ include "mozmoderator.chart" . }}
+{{ include "mozmoderator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mozmoderator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mozmoderator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mozmoderator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "mozmoderator.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/mozmoderator/templates/configmap.yaml
+++ b/charts/mozmoderator/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "mozmoderator.fullname" . }}
+data:
+  ALLOWED_HOSTS: {{ .Values.configMap.allowedHosts }}
+  ANON_ALWAYS: "True"
+  MOZILLIANS_API_URL: "https://mozillians.org/api/v2/"
+  MOZILLIANS_API_BASE: "https://mozillians.org/api/v1/users/"
+  OIDC_OP_DOMAIN: "auth.mozilla.auth0.com"
+  OIDC_OP_AUTHORIZATION_ENDPOINT: "https://auth.mozilla.auth0.com/authorize"
+  OIDC_OP_TOKEN_ENDPOINT: "https://auth.mozilla.auth0.com/oauth/token"
+  OIDC_OP_USER_ENDPOINT: "https://auth.mozilla.auth0.com/userinfo"
+  SESSION_COOKIE_SECURE: "True"
+  SITE_URL: {{ .Values.configMap.siteUrl }}
+  OIDC_RP_SIGN_ALGO: 'RS256'
+  OIDC_OP_JWKS_ENDPOINT: "https://auth.mozilla.auth0.com/.well-known/jwks.json"

--- a/charts/mozmoderator/templates/deployment.yaml
+++ b/charts/mozmoderator/templates/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mozmoderator.fullname" . }}
+  labels:
+    {{- include "mozmoderator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "mozmoderator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mozmoderator.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+          - configMapRef:
+              name: {{ include "mozmoderator.fullname" . }}
+          - secretRef:
+              name: {{ include "mozmoderator.fullname" . }}

--- a/charts/mozmoderator/templates/ingress.yaml
+++ b/charts/mozmoderator/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mozmoderator.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mozmoderator.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/mozmoderator/templates/secret.yaml
+++ b/charts/mozmoderator/templates/secret.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.externalSecret.create -}}
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "mozmoderator.fullname" . }}
+spec:
+  backendType: secretsManager
+  dataFrom:
+  - /{{ .Values.environment }}/moderator
+{{- else }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "mozmoderator.fullname" . }}
+data:
+  DATABASE_URL: bG9jYWxob3N0
+  MOZILLIANS_API_APPNAME: bW9kZXJhdG9y
+  MOZILLIANS_API_KEY: ZmFrZQ==
+  OIDC_RP_CLIENT_ID: ZmFrZQ==
+  OIDC_RP_CLIENT_SECRET: ZmFrZQ==
+  SECRET_KEY: ZmFrZQ==
+{{- end }}

--- a/charts/mozmoderator/templates/service.yaml
+++ b/charts/mozmoderator/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mozmoderator.fullname" . }}
+  labels:
+    {{- include "mozmoderator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "mozmoderator.selectorLabels" . | nindent 4 }}

--- a/charts/mozmoderator/templates/tests/test-connection.yaml
+++ b/charts/mozmoderator/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "mozmoderator.fullname" . }}-test-connection"
+  labels:
+    {{- include "mozmoderator.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "mozmoderator.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/mozmoderator/values.yaml
+++ b/charts/mozmoderator/values.yaml
@@ -1,0 +1,47 @@
+replicaCount: 1
+environment: stage
+
+image:
+  repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/moderator
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: "moderator"
+
+podSecurityContext: {}
+
+securityContext:
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx-moderator
+  hosts:
+    - host: moderator.mozilla.org
+      paths:
+        - /
+      backend:
+        serviceName: moderator
+        servicePort: 80
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 20m
+    memory: 64Mi
+
+configMap:
+  allowedHosts: "moderator.mozilla.org,moderator-prod.itsre-apps.mozit.cloud"
+  siteUrl: "https://moderator.mozilla.org"
+
+externalSecret:
+  create: false


### PR DESCRIPTION
This PR adds a new Helm Chart for MozModerator (https://github.com/mozilla/mozmoderator). It will be used for deploying the application in our new clusters.

The chart was created using `helm create mozmoderator`. That command creates a boilerplate with the main yaml files as well as helpers and notes. From there, it was modified to match the application definition.
Currently, the application is defined using static Kubernetes manifests [here](https://github.com/mozilla/mozmoderator/tree/master/kubernetes).

The tests are expected to fail, because the container specified lives in ECR so the test suite needs permissions to pull that container. I'm thinking about an elegant and secure way to get the credentials there, but until I find it (involving the rest of the team) it's going to be like this
