### PR TITLE
Allow Travis to Pull Containers from ECR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,40 +1,36 @@
 language: minimal
 sudo: required
-
 if: branch = main
-
 stages:
-  - Lint and Validate
-  - Deploy
-
+- Lint and Validate
+- Deploy
 install:
-  - ./ci/setup.sh
-
+- "./ci/setup.sh"
 jobs:
-  - stage: Lint and Validate
-    script:
-      - ./ci/lint.sh
-  - stage: e2e
-    script:
-      - ./ci/e2e.sh
-  - stage: Deploy
-    if: type = push AND branch = main
-    script:
-      - ./ci/release.sh
-    deploy:
-      provider: pages
-      github_token: $GITHUB_TOKEN
-      local_dir: releases
-      verbose: true
-      keep_history: true
-      skip_cleanup: true
-      target_branch: gh-pages
-      on:
-        branch: main
-
+- stage: Lint and Validate
+  script:
+  - "./ci/lint.sh"
+- stage: e2e
+  script:
+  - "./ci/e2e.sh"
+- stage: Deploy
+  if: type = push AND branch = main
+  script:
+  - "./ci/release.sh"
+  deploy:
+    provider: pages
+    github_token: "$GITHUB_TOKEN"
+    local_dir: releases
+    verbose: true
+    keep_history: true
+    skip_cleanup: true
+    target_branch: gh-pages
+    on:
+      branch: main
 git:
   depth: false
-
 env:
   global:
-    secure: JMQG7Yl/OqA0SRO7bYsZjP1d/VQ1IVutZ+7USKFIcSIWl7Qi9pnHnBTJVfs2Wa3rYcjHRSfd+oSjc9OKHY0QwQ8vPYURWeaDGYLIWjUSntb77KoG9pWXc6+R+3SoSL+gLIeg4s/EbJK2HAdKeFR6iHezxCjC1pRsPLZaDcGkOEyS5paV3AsRmPj4ytPLH+m2w2jpcqykV60FhQf5+gefJkDrZ19jBjqtbLe1BMAzvAqmOZkqv+PF0XOZJmu4RU0nMxzRW2xpaWyv4mTztky41gQMMDk2/8MBN7jM3sLZNA0qVZUr9FmVCpKyD4dTpgLVpCTDMKLmo6OKFMnLx45yohdwJm8H7ZAWBaurEjZ8MFwrIlZ38tEXmifgo/p/dPRHGUMcyon8iCEc4F7Sju2prfqf9EhBg+fSnBzOFROwjEywUZMArTQsRuk/Uu/50MSNzhKvAQ3LGX9dc0Oo6FvWEJmmh/n+4ZxyPHmStUR2prMVsdPJFVNc7pPR7AKJ0VlkcKsB1uMUc4K43hDJCPXHIzI40p0aBEfvq0UW0xmqyKOOCWoSABNHuU7cqk4motyzOrth1G0S42LAzDHm4qlos3X+YEzDBw6on8GTGHETAd7N6Ih4Fx3ymG0KbhHWdflOj1CPocY4eR6aPtvomZiVfozd2oepPQCerSGxyH8HVvE=
+  - secure: JMQG7Yl/OqA0SRO7bYsZjP1d/VQ1IVutZ+7USKFIcSIWl7Qi9pnHnBTJVfs2Wa3rYcjHRSfd+oSjc9OKHY0QwQ8vPYURWeaDGYLIWjUSntb77KoG9pWXc6+R+3SoSL+gLIeg4s/EbJK2HAdKeFR6iHezxCjC1pRsPLZaDcGkOEyS5paV3AsRmPj4ytPLH+m2w2jpcqykV60FhQf5+gefJkDrZ19jBjqtbLe1BMAzvAqmOZkqv+PF0XOZJmu4RU0nMxzRW2xpaWyv4mTztky41gQMMDk2/8MBN7jM3sLZNA0qVZUr9FmVCpKyD4dTpgLVpCTDMKLmo6OKFMnLx45yohdwJm8H7ZAWBaurEjZ8MFwrIlZ38tEXmifgo/p/dPRHGUMcyon8iCEc4F7Sju2prfqf9EhBg+fSnBzOFROwjEywUZMArTQsRuk/Uu/50MSNzhKvAQ3LGX9dc0Oo6FvWEJmmh/n+4ZxyPHmStUR2prMVsdPJFVNc7pPR7AKJ0VlkcKsB1uMUc4K43hDJCPXHIzI40p0aBEfvq0UW0xmqyKOOCWoSABNHuU7cqk4motyzOrth1G0S42LAzDHm4qlos3X+YEzDBw6on8GTGHETAd7N6Ih4Fx3ymG0KbhHWdflOj1CPocY4eR6aPtvomZiVfozd2oepPQCerSGxyH8HVvE=
+  - secure: fQJqZlg8nhDPhn2zZX6c+mcSZsulkXFfZI1qo3pzZ2vmcmaqmRSUe8XbseVQKt94CmtilfuNE3P+ZVqpCNZPD0zsa6fu3CE14nhRiess4T3L111APNgP1SXEfxQoY+1/ZT9584R38mBMrS0quCnAYMl9aYwTHwhfTRIvHO05DVmlh1t/u6remLj7U+vayClAc5B3JsLGt5aplQ8FurHP/P6olJc/mUwvE9KFVsna7MUPO0KT0VBUu4cILHX7sjwVsBHchZpRenO5ukPJoOjDwxjLERqQr/m6Io5a60PE1WrO5sjl6IkvKDKii8C1ij3SOzpkW3TKLYbmAip5eyVSy+wZpSZzcZBIXPnezyleRsyngiom/0Mp4xJYU9s0n8133RKEHB3k5aeRWr99Jw7qUamtFZbvY7Qxg2BiEL6qMHkP4ns85vovE5w8pG5GT7j4dPvtfefypiDzquE5phMKFpJ6q5riNVG459bWx6U9CXeb09//O3oKg+x7gWB9aascz8sWFgFU6/3e/20hzNVBiT+AsNFI3W7XrU1GZ38BHyJ6niauHPIThPRSmTtmyg5ZMPX2gCmvALT050la8yyWeNnIzBTAtSIcBS2d7jJP2QYRF0SdlNhhX2zG66z0hC8udos+iiuuXWmCBVc4l2eaY8z4RqaeEV7NEDlmErsGLKY=
+  - secure: OVHfTUZbIrM7H4HdB9z5dwwOapjz1HmoytX/sKXanrmLfS4Eoyio+Ib6YQO9lVGsoxvsYG2xUohjDmKpKYhaiy3QEfqeKGJdgDWU6WzZ1OUyPTqL7CPo9wGovWbAbF7mNPBdj3x5qDOp8xvbMqrx33ot2wVkI9tfYenjJ0/MBQSqbyRJGxJ3/9SeK5wSscTX6osNkiwRW4ekr7DpzdHiPYhQ23Ffc6qyep5/kIdqxTXjGD5PAwKAKqtyTD8eToqBCFlT+jNjeMv63fNWc4wIb6Nzwoa+6xTx+Df6plLg9dMSSTY2qgLq8D/Rt1rTRtRwOINIoHeTJPryYPhVSAjdCxBbgqUNkAz2ATxdPBcJwhJM6iBXEOSv+UKOaiEx3gpzFYuTiZ03PHjpNlgiTLLX6qOm0TGMjF7urhpfiLfMc/sutiPw3cIo6jR2nhxlOr7nFRvewDZqw1ykK7n58MC357U58073rIw1breLttrS8/PpVIRR+AYzI7KgDMch0X1nLt5gtU4Q6tOusqlfc/rbm6EEXN9iuahfPqVjW5GFYOMofzqUbutm81hC5dIwnGrEl5FKbNaxrJrQoCHDvpYYxao8Tvc/CFlm1yY9tKk/DheaNTGdkoUROrPeV4yXzFqB6x7f2ixRDo23NTSfpjPE3/4lH8Qr57jZce7bCa7HjUs=

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -4,6 +4,7 @@ readonly REPO_ROOT=$(git rev-parse --show-toplevel)
 readonly FUNCTIONS="${REPO_ROOT}/ci/functions.sh"
 readonly CLUSTER_NAME="${CLUSTER_NAME:-kind}"
 readonly CONFIG_FILE="${REPO_ROOT}/ci/kind.yaml"
+readonly NAMESPACE="chart-ci-e2e"
 
 # shellcheck source=ci/functions.sh
 [ -f "${FUNCTIONS}" ] && source "${FUNCTIONS}" || exit 1
@@ -15,13 +16,24 @@ create_kind_cluster() {
         --name "${CLUSTER_NAME}" \
         --config "${CONFIG_FILE}" \
         --wait 60s
+}
 
+configure_kind_cluster() {
     configure_kube
 
     kubectl cluster-info
     echo
 
     kubectl get nodes
+    echo
+    
+    if [[ $(kubectl get namespaces | grep -w $NAMESPACE) ]] ; then
+        # If the NS exists, delete it and recreate it to get a clean state
+        kubectl delete namespace $NAMESPACE
+        kubectl create namespace $NAMESPACE
+    else
+        kubectl create namespace $NAMESPACE
+    fi
     echo
 
     echo 'Cluster ready..'
@@ -40,15 +52,45 @@ configure_kube() {
 
 install_charts() {
     echo 'Installing charts...'
-    docker_exec ct install
+    docker_exec ct install --namespace $NAMESPACE
     echo
+}
+
+check_cluster_exists () {
+    # 0 if cluster already exists
+    kind get clusters | grep -q -w "$CLUSTER_NAME"
+    echo $?
+}
+
+create_ecr_secret () {
+    # Gets a valid token to pull from ECR and creates a secret with it
+    ACCOUNT=$(aws sts get-caller-identity --output text --query Account)
+    REGION=us-west-2
+    SECRET_NAME=ecr-registry
+    EMAIL=itse@mozilla.com
+
+    # Fetch token (which will expire in 12 hours)
+    TOKEN=$(aws ecr --region=$REGION get-authorization-token --output text --query authorizationData[].authorizationToken | base64 -d | cut -d: -f2)
+
+    # Create or replace secret
+    kubectl delete secret -n $NAMESPACE --ignore-not-found "$SECRET_NAME"
+    kubectl create secret -n $NAMESPACE docker-registry "$SECRET_NAME" \
+     --docker-server="https://${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com" \
+     --docker-username=AWS \
+     --docker-password="${TOKEN}" \
+     --docker-email="${EMAIL}"
 }
 
 main() {
     run_ct_container
     trap cleanup EXIT
 
-    create_kind_cluster
+    if [[ $(check_cluster_exists) != 0 ]] ; then
+        create_kind_cluster
+    fi
+
+    configure_kind_cluster
+    create_ecr_secret
     install_charts
 }
 

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -18,3 +18,6 @@ curl -L "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | tar xz &
 echo "=== Install kind ${KIND_VERSION}"
 curl -sSLo kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64" && chmod +x kind && sudo mv kind /usr/local/bin/kind
 
+echo "=== Install awscli"
+pip install --user awscli
+


### PR DESCRIPTION
This PR allows to test Helm Charts which reference Container Images stored in ECR.
Before this, when the chart was end-to-end tested, and the container image was stored in ECR, the test were failing because the "kind" cluster didn't have enough permissions to pull the image.

This changes leverages the standard Kubernetes way of pasing this kind of credentials, which is using a secret file. More on this in the [official documentation](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod).

From here on, pulling from ECR is possible adding specifying the name of the secret in your chart/ci folder. For mozmoderator chart, it goes like this:
```
cat mozmoderator/ci/test-values.yaml 
imagePullSecrets:
  - name: ecr-registry 
```