### PR TITLE
Explicitly set target branch in ct.yaml file

### DIFF
--- a/ci/ct.yaml
+++ b/ci/ct.yaml
@@ -4,6 +4,7 @@ check-version-increment: true
 validate-yaml: true
 validate-chart-schema: false
 validate-maintainers: false
+target-branch: main
 
 chart-dirs:
   - charts


### PR DESCRIPTION
The lint command's default branch is to assume its on `master`

Set the `target-branch` setting to `main` in `ct.yaml`