### PR TITLE
Add consistent labels for refractr helm charts

### DIFF
--- a/charts/refractr/Chart.yaml
+++ b/charts/refractr/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the refractr redirect application
 type: application
 
 # Chart version, bump for any changes
-version: 1.0.8
+version: 1.0.9
 
 keywords:
   - Mozilla

--- a/charts/refractr/templates/_helpers.tpl
+++ b/charts/refractr/templates/_helpers.tpl
@@ -36,6 +36,7 @@ Common labels
 */}}
 {{- define "refractr.labels" -}}
 app: {{ include "refractr.fullname" . }}
+environment: {{ .Values.environment }}
 helm.sh/chart: {{ include "refractr.chart" . }}
 {{ include "refractr.selectorLabels" . }}
 {{- if .Chart.AppVersion }}

--- a/charts/refractr/templates/ingress-hook.yaml
+++ b/charts/refractr/templates/ingress-hook.yaml
@@ -6,6 +6,8 @@ metadata:
   name: refractr
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
+  labels:
+    {{- include "refractr.labels" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
@@ -13,6 +15,8 @@ metadata:
   name: refractr
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
+  labels:
+    {{- include "refractr.labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -62,6 +66,8 @@ metadata:
   name: refractr
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
+  labels:
+    {{- include "refractr.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -77,9 +83,7 @@ kind: Job
 metadata:
   name: "{{ .Release.Name }}-ingress-preinstall-hook"
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- include "refractr.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
 spec:
@@ -87,9 +91,7 @@ spec:
     metadata:
       name: "{{ .Release.Name }}-ingress-preinstall-hook"
       labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        {{- include "refractr.labels" . | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
This sets consistent labels across all resources that `refractr` uses 