### PR TITLE
Fixing charts to make it pass helm lints

### DIFF
--- a/charts/fluentd-papertrail/Chart.yaml
+++ b/charts/fluentd-papertrail/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: fluentd-papertrail
 description: A Helm chart to deploy fluentd to send to papertrail
 type: application
-version: 0.1.2
-appVersion: 1.2
+version: 0.1.3
+appVersion: "1.2"
 
 keywords:
   - fluentd

--- a/charts/mozilla-common-voice/Chart.lock
+++ b/charts/mozilla-common-voice/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: kibana
   repository: https://helm.elastic.co
   version: 7.6.2
-digest: sha256:93a41a9b9e28be227dc954520268ea6f17fde8d199e7b47893a5aa58fa8c0529
-generated: "2020-07-09T10:49:00.407093456+02:00"
+digest: sha256:ef52a0dac1cc9a506542fd45c9e381e5a36bfcb43d2a8e767b1df4945e50281a
+generated: "2020-09-22T08:11:34.651001162Z"

--- a/charts/mozilla-common-voice/Chart.yaml
+++ b/charts/mozilla-common-voice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mozilla-common-voice
 icon: https://voice.mozilla.org/dist/f01895c77138837851f87c2e40acbd58.svg
-version: 0.3.0
+version: 0.3.1
 description: Deploy Mozilla Common Voice web application
 type: application
 keywords:
@@ -27,7 +27,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com
 
 - name: elasticsearch
-  version: ~7.6.0
+  version: 7.6.2
   condition: elasticsearch.enabled
   repository: https://helm.elastic.co
 

--- a/charts/mozilla-common-voice/templates/ingress.yaml
+++ b/charts/mozilla-common-voice/templates/ingress.yaml
@@ -1,5 +1,9 @@
 {{ if eq .Values.voice_web.ingress.enabled true }}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: voice-ingress

--- a/charts/mozilla-common-voice/values.yaml
+++ b/charts/mozilla-common-voice/values.yaml
@@ -23,7 +23,7 @@ voice_web:
     cpu: 1
     memory: 1024Mi
 
-  image: "itsre/voice-web:master-latest"
+  image: "mozilla/commonvoice:stage-latest"
 
   service_account:
     annotations: {}


### PR DESCRIPTION
After updating helm in PR #53 it appears that lints are failing because of certain `apiVersion` has been deprecated. This PR resolves some of the errors based on the errors that `helm lint` is throwing as well as fixing some deprecated api's

See https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ for more info