### PR TITLE
Update refractr hpa template

### DIFF
--- a/charts/refractr/Chart.yaml
+++ b/charts/refractr/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the refractr redirect application
 type: application
 
 # Chart version, bump for any changes
-version: 1.0.11
+version: 1.0.12
 
 keywords:
   - Mozilla

--- a/charts/refractr/templates/hpa.yaml
+++ b/charts/refractr/templates/hpa.yaml
@@ -12,5 +12,21 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ .Values.deployment.name }}
-  targetCPUUtilizationPercentage: {{ .Values.hpa.target_cpu_utilization }}
+  metrics:
+    {{- with .Values.hpa.target_cpu_utilization }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.hpa.target_memory_utilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
 {{ end }}

--- a/charts/refractr/values.yaml
+++ b/charts/refractr/values.yaml
@@ -49,6 +49,7 @@ hpa:
   max_replicas: 6
   min_replicas: 3
   target_cpu_utilization: 80
+  target_memory_utilization: 80
 
 resources:
   # This value is taken ingress-nginx


### PR DESCRIPTION
Update refract hpa template to explicitly check cpu and memory resource, this is similar to what the ingress controller does

Hopefully this fixes the issue where hpa is unable to grab the cpu metrics