### PR TITLE
Moving annotations from deployment to the pod level.

### DIFF
--- a/charts/refractr/Chart.yaml
+++ b/charts/refractr/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the refractr redirect application
 type: application
 
 # Chart version, bump for any changes
-version: 1.0.16
+version: 1.0.17
 
 keywords:
   - Mozilla

--- a/charts/refractr/templates/deployment.yaml
+++ b/charts/refractr/templates/deployment.yaml
@@ -17,6 +17,11 @@ spec:
   template:
     metadata:
       labels: {{- include "refractr.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- if .Values.metrics.enabled }}
+        prometheus.io/port: {{ .Values.metrics.port | quote }}
+        prometheus.io/scrape: "true"
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/refractr/values.yaml
+++ b/charts/refractr/values.yaml
@@ -41,8 +41,6 @@ deployment:
     fluxcd.io/automated: "true"
     fluxcd.io/tag.refractr-web: glob:dev-*
     # Needs to be kept in sync with metrics settings down below
-    prometheus.io/port: "9113"
-    prometheus.io/scrape: "true"
   name: refractr
   extraContainers: []
   extraVolumes: []


### PR DESCRIPTION
Also making this a bit smarter, if we're making the metrics pod let's scrape it
And use the same port as what's exposed by the pod