### PR TITLE
Add dataset bucket to config-map also

### DIFF
--- a/charts/mozilla-common-voice/Chart.yaml
+++ b/charts/mozilla-common-voice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mozilla-common-voice
 icon: https://voice.mozilla.org/dist/f01895c77138837851f87c2e40acbd58.svg
-version: 0.4.0
+version: 0.4.1
 description: Deploy Mozilla Common Voice web application
 type: application
 keywords:

--- a/charts/mozilla-common-voice/templates/configmap.yaml
+++ b/charts/mozilla-common-voice/templates/configmap.yaml
@@ -12,6 +12,8 @@ data:
   CV_MYSQLHOST: "{{ .Values.voice_web.config.mysql.host }}"
   CV_MYSQLPORT:  "{{ .Values.voice_web.config.mysql.port }}"
   CV_BUCKET_NAME: "{{ .Values.voice_web.config.s3.bucket_name }}"
+  CV_CLIP_BUCKET_NAME: "{{ .Values.voice_web.config.s3.clip_bucket_name }}"
+  CV_DATASET_BUCKET_NAME: "{{ .Values.voice_web.config.s3.dataset_bucket_name }}"
   CV_BUCKET_LOCATION: "{{ .Values.voice_web.config.s3.location }}"
   CV_ENVIRONMENT: "{{ .Values.voice_web.config.environment }}"
   CV_ADMIN_EMAILS: "{{ .Values.voice_web.config.admin_emails }}"


### PR DESCRIPTION
@The-smooth-operator I've left the BUCKET_NAME in there for now just for backwards compatibility, assuming the changes to accommodate old datasets won't be ready concurrently on all environments.