### PR TITLE
Adding a db-migration

### DIFF
--- a/charts/ctms/Chart.yaml
+++ b/charts/ctms/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Mozilla's CTMS-API app
 
 type: application
 
-version: 0.0.2
+version: 0.0.3

--- a/charts/ctms/templates/NOTES.txt
+++ b/charts/ctms/templates/NOTES.txt
@@ -1,8 +1,8 @@
-1. Get the application URL by running these commands:
+1. check that the application deployed well by running the following commands
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  curl https://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}

--- a/charts/ctms/templates/db-migration.yaml
+++ b/charts/ctms/templates/db-migration.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "ctms.fullname" . }}
+  labels:
+    {{- include "ctms.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: {{ .Chart.Name }}-db-migration
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        command: ["python", "-m", "alembic", "upgrade", "head"]
+
+

--- a/charts/ctms/templates/secrets.yaml
+++ b/charts/ctms/templates/secrets.yaml
@@ -7,11 +7,38 @@ spec:
   backendType: secretsManager
   dataFrom:
   - {{ .Values.externalSecrets.secretName }}
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "ctms.fullname" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  backendType: secretsManager
+  dataFrom:
+  - {{ .Values.externalSecrets.secretName }}
 {{- else }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "ctms.fullname" . }}
+data:
+  # echo -n "postgres://ctms:defaultpassword@postgres:5432/ctms" | base64 -w 0
+  DATABASE_URL: cG9zdGdyZXM6Ly9tZW50b3Jpbmc6ZGVmYXVsdHBhc3N3b3JkQHBvc3RncmVzOjU0MzIvbWVudG9yaW5n
+  # echo -n "this-is-not-the-production-value" | base64
+  DJANGO_SECRET_KEY: dGhpcy1pcy1ub3QtdGhlLXByb2R1Y3Rpb24tdmFsdWU=
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ctms.fullname" . }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": hook-succeeded
 data:
   # echo -n "postgres://ctms:defaultpassword@postgres:5432/ctms" | base64 -w 0
   DATABASE_URL: cG9zdGdyZXM6Ly9tZW50b3Jpbmc6ZGVmYXVsdHBhc3N3b3JkQHBvc3RncmVzOjU0MzIvbWVudG9yaW5n


### PR DESCRIPTION
adds a job that runs on each install and each upgrade
uses the same image as the deployment
makes secrets accessible in the hook