### PR TITLE
Adding a property to access key in dict

### DIFF
--- a/charts/prometheus-customizations/Chart.yaml
+++ b/charts/prometheus-customizations/Chart.yaml
@@ -4,4 +4,4 @@ description: An opinionated helm chart to setup our prometheus instances. Requir
 
 type: application
 
-version: 0.0.1
+version: 0.0.2

--- a/charts/prometheus-customizations/templates/influx-secret.yml
+++ b/charts/prometheus-customizations/templates/influx-secret.yml
@@ -9,4 +9,5 @@ spec:
   data:
     - key: "{{ .Values.influxdb.secret_key }}"
       name: "{{ .Values.influxdb.secret_name }}"
+      property: "{{ .Values.influxdb.property }}"
 {{- end }}

--- a/charts/prometheus-customizations/values.yaml
+++ b/charts/prometheus-customizations/values.yaml
@@ -7,3 +7,4 @@ influxdb:
   enabled: false
   secret_key: "/prometheus/influx"
   secret_name: "influxurl"
+  property: "influxurl"


### PR DESCRIPTION
Secrets have key/name and property to correctly go to aws secrets manager and get all the info stored correctly.