### PR TITLE
Add a background job deployment for ctms

### DIFF
--- a/charts/ctms/Chart.yaml
+++ b/charts/ctms/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Mozilla's CTMS-API app
 
 type: application
 
-version: 0.0.10
+version: 0.0.11

--- a/charts/ctms/templates/background_deployment.yaml
+++ b/charts/ctms/templates/background_deployment.yaml
@@ -3,13 +3,13 @@ kind: Deployment
 metadata:
   name: {{ include "ctms.fullname" . }}
   labels:
+    app.kubernetes.io/component: background
     {{- include "ctms.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
+  replicas: 1
   selector:
     matchLabels:
+      app.kubernetes.io/component: background
       {{- include "ctms.selectorLabels" . | nindent 6 }}
   template:
     metadata:
@@ -18,6 +18,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        app.kubernetes.io/component: background
         {{- include "ctms.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -32,19 +33,10 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ["python"]
+          args:
+            - "ctms/bin/acoustic_sync.py"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: 8000
-              protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /__lbheartbeat__
-              port: http
-          readinessProbe:
-            httpGet:
-              path: /__lbheartbeat__
-              port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           envFrom:

--- a/charts/ctms/templates/service.yaml
+++ b/charts/ctms/templates/service.yaml
@@ -12,4 +12,5 @@ spec:
       protocol: TCP
       name: http
   selector:
+    app.kubernetes.io/component: web
     {{- include "ctms.selectorLabels" . | nindent 4 }}

--- a/charts/ctms/templates/web_deployment.yaml
+++ b/charts/ctms/templates/web_deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ctms.fullname" . }}
+  labels:
+    app.kubernetes.io/component: web
+    {{- include "ctms.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: web
+      {{- include "ctms.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/component: web
+        {{- include "ctms.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "ctms.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /__lbheartbeat__
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /__lbheartbeat__
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+          - configMapRef:
+              name: {{ include "ctms.fullname" . }}
+          - secretRef:
+              name: {{ include "ctms.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
This is a first cut at this, still needs some extra work but wanted to get something up now for a first review.

My thinking was that this is basically the same as the deployment that was there already but without some things that only make sense for pods exposing ports. I updated the selectors so that the service should expose the web deployment but not the background one.

It's been a bit since I did something like this so feel free to tell me to trash this whole thing and start again.