### PR TITLE
Fixing up the helm chart pipeline for ctms

### DIFF
--- a/charts/ctms/Chart.yaml
+++ b/charts/ctms/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Mozilla's CTMS-API app
 
 type: application
 
-version: 0.0.15
+version: 0.0.16

--- a/charts/ctms/ci/test-values.yaml
+++ b/charts/ctms/ci/test-values.yaml
@@ -1,2 +1,6 @@
 imagePullSecrets:
   - name: ecr-registry
+
+image:
+  repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/ctms-api
+  tag: "v1.0.0"

--- a/charts/ctms/templates/db-migration.yaml
+++ b/charts/ctms/templates/db-migration.yaml
@@ -14,6 +14,10 @@ spec:
     metadata:
       name: "{{ .Release.Name }}"
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       restartPolicy: Never
       containers:
       - name: {{ .Chart.Name }}-db-migration

--- a/charts/ctms/templates/secrets.yaml
+++ b/charts/ctms/templates/secrets.yaml
@@ -27,9 +27,21 @@ metadata:
   name: {{ include "ctms.fullname" . }}
 data:
   # echo -n "postgres://ctms:defaultpassword@postgres:5432/ctms" | base64 -w 0
-  DATABASE_URL: cG9zdGdyZXM6Ly9tZW50b3Jpbmc6ZGVmYXVsdHBhc3N3b3JkQHBvc3RncmVzOjU0MzIvbWVudG9yaW5n
+  CTMS_DB_URL: cG9zdGdyZXM6Ly9jdG1zOmRlZmF1bHRwYXNzd29yZEBwb3N0Z3Jlczo1NDMyL2N0bXM=
   # echo -n "this-is-not-the-production-value" | base64
-  DJANGO_SECRET_KEY: dGhpcy1pcy1ub3QtdGhlLXByb2R1Y3Rpb24tdmFsdWU=
+  CTMS_SECRET_KEY: dGhpcy1pcy1ub3QtdGhlLXByb2R1Y3Rpb24tdmFsdWU=
+  CTMS_ACOUSTIC_LOOP_MIN_SECS: NQ==
+  # false
+  CTMS_ACOUSTIC_SYNC_FEATURE_FLAG: ZmFsc2U=
+  CTMS_ACOUSTIC_INTEGRATION_FEATURE_FLAG: ZmFsc2U=
+  # 111111
+  CTMS_ACOUSTIC_MAIN_TABLE_ID: MTExMTE=
+  CTMS_ACOUSTIC_NEWSLETTER_TABLE_ID: MTExMTE=
+  # just a bunch of fake strings, value is mostly unimportant here
+  CTMS_ACOUSTIC_CLIENT_ID: ZmFrZWNsaWVudGlk
+  CTMS_ACOUSTIC_CLIENT_SECRET: ZmFrZWNsaWVudHNlY3JldA==
+  CTMS_ACOUSTIC_REFRESH_TOKEN: ZmFrZXJlZnJlc2h0b2tlbg==
+  CTMS_PROMETHEUS_PUSHGATEWAY_URL: cHJvbWV0aGV1cy1wdXNoZ2F0ZXdheQ==
 ---
 apiVersion: v1
 kind: Secret
@@ -41,8 +53,8 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
 data:
   # echo -n "postgres://ctms:defaultpassword@postgres:5432/ctms" | base64 -w 0
-  DATABASE_URL: cG9zdGdyZXM6Ly9tZW50b3Jpbmc6ZGVmYXVsdHBhc3N3b3JkQHBvc3RncmVzOjU0MzIvbWVudG9yaW5n
+  CTMS_DB_URL: cG9zdGdyZXM6Ly9jdG1zOmRlZmF1bHRwYXNzd29yZEBwb3N0Z3Jlczo1NDMyL2N0bXM=
   # echo -n "this-is-not-the-production-value" | base64
-  DJANGO_SECRET_KEY: dGhpcy1pcy1ub3QtdGhlLXByb2R1Y3Rpb24tdmFsdWU=
+  CTMS_SECRET_KEY: dGhpcy1pcy1ub3QtdGhlLXByb2R1Y3Rpb24tdmFsdWU=
 {{- end }}
 

--- a/ci/deps/ctms/install.sh
+++ b/ci/deps/ctms/install.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+
+readonly NAMESPACE="chart-ci-e2e"
+
+
+
+helm upgrade --install \
+  --version 10.4.2 \
+  --namespace $NAMESPACE \
+  --set postgresqlPassword=defaultpassword \
+  --set postgresqlUsername=ctms \
+  --set postgresqlDatabase=ctms \
+  --set fullnameOverride=postgres \
+  postgresql bitnami/postgresql

--- a/ci/deps/ctms/install.sh
+++ b/ci/deps/ctms/install.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
 

--- a/ci/deps/install.sh
+++ b/ci/deps/install.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
+set -e
+
 for d in ci/deps/*/; do
-  echo $d
-  if ls $d/*.sh 1> /dev/null 2>&1; then
-    for f in $d/*.sh; do bash "$f" -H ; done
+  if ls "$d"/*.sh 1> /dev/null 2>&1; then
+    for f in "$d"/*.sh; do bash "$f" -H ; done
   fi
 done

--- a/ci/deps/install.sh
+++ b/ci/deps/install.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+for d in ci/deps/*/; do
+  echo $d
+  if ls $d/*.sh 1> /dev/null 2>&1; then
+    for f in $d/*.sh; do bash "$f" -H ; done
+  fi
+done

--- a/ci/e2e.sh
+++ b/ci/e2e.sh
@@ -46,11 +46,18 @@ configure_kube() {
 
     echo 'Copying kubeconfig to container'
     docker_exec sh -c 'mkdir -p /root/.kube'
+    chmod 600 kind.config
     docker cp kind.config ct:/root/.kube/config
     echo
 }
 
-install_charts() {
+install_deps () {
+  echo 'Installing some dependencies for this pipeline...'
+
+  docker_exec ./ci/deps/install.sh
+}
+
+install_charts () {
     echo 'Installing charts...'
     docker_exec ct install --namespace $NAMESPACE
     echo
@@ -91,6 +98,7 @@ main() {
 
     configure_kind_cluster
     create_ecr_secret
+    install_deps
     install_charts
 }
 


### PR DESCRIPTION
Trying to get the existing pipeline back to green by making ctms helm chart install correctly.
Installing postgres to the cluster for ephemeral testing of the db migration.
Added a new dependency installation pattern to this pipeline to be able to install postgres.
Updated secrets to include new values.