### PR TITLE
dumb yaml error in pastebin secret conditional

### DIFF
--- a/charts/pastebin/Chart.yaml
+++ b/charts/pastebin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pastebin
 description: A Helm chart for the Mozilla Pastebin (dpaste) application
 type: application
-version: 0.1.0
+version: 0.1.1
 
 keywords:
   - Mozilla

--- a/charts/pastebin/templates/deployment.yaml
+++ b/charts/pastebin/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Values.deployment.name }}
-          {{- if .Values.externalSecrets.enabled -}}
+          {{- if .Values.externalSecrets.enabled }}
             - secretRef:
                 name: {{ .Values.deployment.name }}
           {{- end }}

--- a/charts/pastebin/templates/job.yaml
+++ b/charts/pastebin/templates/job.yaml
@@ -27,7 +27,7 @@ spec:
               envFrom:
                 - configMapRef:
                     name: {{ .Values.deployment.name }}
-                {{- if .Values.externalSecrets.enabled -}}
+                {{- if .Values.externalSecrets.enabled }}
                 - secretRef:
                     name: {{ .Values.deployment.name }}
                 {{- end }}


### PR DESCRIPTION
In furtherance of https://mozilla-hub.atlassian.net/browse/SE-1152 (formerly SE-1993)

Get rid of a stray - causing some havoc in a pastebin conditional block added for local dev env support.