### PR TITLE
change ownership of repos charts to it-sre@mozilla.com

### DIFF
--- a/charts/configmapsecrets/Chart.yaml
+++ b/charts/configmapsecrets/Chart.yaml
@@ -5,3 +5,7 @@ description: A Helm chart for https://github.com/machinezone/configmapsecrets
 type: application
 
 version: 0.0.1
+
+maintainers:
+  - name: Web SRE Team
+    email: it-sre@mozilla.com

--- a/charts/configmapsecrets/Chart.yaml
+++ b/charts/configmapsecrets/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for https://github.com/machinezone/configmapsecrets
 
 type: application
 
-version: 0.0.1
+version: 0.0.2
 
 maintainers:
   - name: Web SRE Team

--- a/charts/ctms/Chart.yaml
+++ b/charts/ctms/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Mozilla's CTMS-API app
 
 type: application
 
-version: 0.0.16
+version: 0.0.17
 
 maintainers:
   - name: Web SRE Team

--- a/charts/ctms/Chart.yaml
+++ b/charts/ctms/Chart.yaml
@@ -5,3 +5,7 @@ description: A Helm chart for Mozilla's CTMS-API app
 type: application
 
 version: 0.0.16
+
+maintainers:
+  - name: Web SRE Team
+    email: it-sre@mozilla.com

--- a/charts/data-alert-sender/Chart.yaml
+++ b/charts/data-alert-sender/Chart.yaml
@@ -9,5 +9,5 @@ home: "https://github.com/mozilla-it/data-alert-sender"
 sources:
   - "https://github.com/mozilla-it/data-alert-sender"
 maintainers:
-  - name: mozafrank
-    email: afrank@mozilla.com
+  - name: Web SRE Team
+    email: it-sre@mozilla.com

--- a/charts/data-alert-sender/Chart.yaml
+++ b/charts/data-alert-sender/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: data-alert-sender
 description: Helm Chart for data-alert-sender, a cron job which sends data alerts from stackdriver metrics
-version: 0.0.3
+version: 0.0.4
 appVersion: 0.0.1
 keywords:
   - cron

--- a/charts/fluentd-papertrail/Chart.yaml
+++ b/charts/fluentd-papertrail/Chart.yaml
@@ -16,5 +16,5 @@ sources:
   - https://github.com/fluent/fluentd
 
 maintainers:
-  - name: limed
-    email: limed@mozilla.com
+  - name: Web SRE Team
+    email: it-sre@mozilla.com

--- a/charts/fluentd-papertrail/Chart.yaml
+++ b/charts/fluentd-papertrail/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd-papertrail
 description: A Helm chart to deploy fluentd to send to papertrail
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.2"
 
 keywords:

--- a/charts/mozalert-controller/Chart.yaml
+++ b/charts/mozalert-controller/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.4.0
+version: 0.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/mozalert-controller/Chart.yaml
+++ b/charts/mozalert-controller/Chart.yaml
@@ -19,3 +19,7 @@ version: 0.4.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 1.17.0
+
+maintainers:
+  - name: Web SRE Team
+    email: it-sre@mozilla.com

--- a/charts/mozalert-controller/ci/ct-values.yaml
+++ b/charts/mozalert-controller/ci/ct-values.yaml
@@ -1,0 +1,1 @@
+secretRef: ""

--- a/charts/mozilla-common-voice/Chart.yaml
+++ b/charts/mozilla-common-voice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mozilla-common-voice
 icon: https://voice.mozilla.org/dist/f01895c77138837851f87c2e40acbd58.svg
-version: 0.4.3
+version: 0.4.4
 description: Deploy Mozilla Common Voice web application
 type: application
 keywords:

--- a/charts/mozilla-common-voice/Chart.yaml
+++ b/charts/mozilla-common-voice/Chart.yaml
@@ -13,8 +13,8 @@ home: https://voice.mozilla.org
 sources:
   - https://github.com/mozilla/voice-web
 maintainers:
-  - name: Alberto del Barrio
-    email: alberto@mozilla.com
+  - name: Web SRE Team
+    email: it-sre@mozilla.com
 dependencies:
 - name: mysql
   version: 8.4.2

--- a/charts/mozmoderator/Chart.yaml
+++ b/charts/mozmoderator/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
 sources:
   - https://github.com/mozilla/mozmoderator
 maintainers:
-  - name: Christina Harlow
-    email: charlow@mozilla.com
+  - name: Web SRE Team
+    email: it-sre@mozilla.com
 
 dependencies:
 - name: cert-manager

--- a/charts/mozmoderator/Chart.yaml
+++ b/charts/mozmoderator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mozmoderator
 description: A Helm Chart for Mozilla's Moderator application
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: c285426edacb3a1791bab84f64c16d00e6d865eb
 keywords:
   - Mozilla

--- a/charts/pastebin/Chart.yaml
+++ b/charts/pastebin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pastebin
 description: A Helm chart for the Mozilla Pastebin (dpaste) application
 type: application
-version: 0.1.1
+version: 0.1.2
 
 keywords:
   - Mozilla

--- a/charts/pastebin/Chart.yaml
+++ b/charts/pastebin/Chart.yaml
@@ -14,8 +14,8 @@ sources:
   - https://github.com/mozilla-it/pastebin
 
 maintainers:
-  - name: Christina Harlow
-    email: charlow@mozilla.com
+  - name: Web SRE Team
+    email: it-sre@mozilla.com
 
 dependencies:
 - name: cert-manager

--- a/charts/prometheus-customizations/Chart.yaml
+++ b/charts/prometheus-customizations/Chart.yaml
@@ -5,3 +5,7 @@ description: An opinionated helm chart to setup our prometheus instances. Requir
 type: application
 
 version: 0.0.2
+
+maintainers:
+  - name: Web SRE Team
+    email: it-sre@mozilla.com

--- a/charts/prometheus-customizations/Chart.yaml
+++ b/charts/prometheus-customizations/Chart.yaml
@@ -4,7 +4,7 @@ description: An opinionated helm chart to setup our prometheus instances. Requir
 
 type: application
 
-version: 0.0.2
+version: 0.0.3
 
 maintainers:
   - name: Web SRE Team

--- a/charts/refractr/Chart.yaml
+++ b/charts/refractr/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the refractr redirect application
 type: application
 
 # Chart version, bump for any changes
-version: 1.0.25
+version: 1.0.26
 
 keywords:
   - Mozilla

--- a/charts/refractr/Chart.yaml
+++ b/charts/refractr/Chart.yaml
@@ -16,8 +16,8 @@ sources:
   - https://github.com/mozilla-it/refractr
 
 maintainers:
-  - name: Alberto del Barrio
-    email: alberto@mozilla.com
+  - name: Web SRE Team
+    email: it-sre@mozilla.com
 
 dependencies:
 - name: cert-manager

--- a/charts/refractr/Chart.yaml
+++ b/charts/refractr/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the refractr redirect application
 type: application
 
 # Chart version, bump for any changes
-version: 1.0.26
+version: 1.1.0
 
 keywords:
   - Mozilla

--- a/charts/refractr/templates/ingress-hook.yaml
+++ b/charts/refractr/templates/ingress-hook.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     {{- include "refractr.labels" . | nindent 4 }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: refractr
@@ -61,7 +61,7 @@ rules:
       - delete
       - watch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: refractr

--- a/charts/sentence-collector/Chart.yaml
+++ b/charts/sentence-collector/Chart.yaml
@@ -12,8 +12,8 @@ home: https://commonvoice.mozilla.org/sentence-collector
 sources:
   - https://github.com/Common-Voice/sentence-collector
 maintainers:
-  - name: Alberto del Barrio
-    email: alberto@mozilla.com
+  - name: Web SRE Team
+    email: it-sre@mozilla.com
 
 dependencies:
 - name: mysql

--- a/charts/sentence-collector/Chart.yaml
+++ b/charts/sentence-collector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: sentence-collector
 description: A Helm chart for Common Voice's Sentence Collector
 type: application
-version: 0.1.1
+version: 0.1.2
 keywords:
   - Mozilla
   - common-voice


### PR DESCRIPTION
Jira: Came up in context of pastebin & mozmoderator helm charts

What this PR does:
* changes maintainers to just say Web SRE team & include the it-sre@mozilla.com email. 