### PR TITLE
update mozmoderator chart to not default to dev args, maintainer=team

### DIFF
--- a/charts/mozmoderator/Chart.yaml
+++ b/charts/mozmoderator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mozmoderator
 description: A Helm Chart for Mozilla's Moderator application
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: c285426edacb3a1791bab84f64c16d00e6d865eb
 keywords:
   - Mozilla
@@ -10,8 +10,8 @@ keywords:
 sources:
   - https://github.com/mozilla/mozmoderator
 maintainers:
-  - name: Christina Harlow
-    email: charlow@mozilla.com
+  - name: Web SRE Team
+    email: it-sre@mozilla.com
 
 dependencies:
 - name: cert-manager

--- a/charts/mozmoderator/templates/deployment.yaml
+++ b/charts/mozmoderator/templates/deployment.yaml
@@ -30,7 +30,6 @@ spec:
     spec:
       containers:
         - name: {{ .Values.deployment.name }}
-          args: ["./bin/run-dev.sh"]
           envFrom:
             - configMapRef:
                 name: {{ .Values.deployment.name }}


### PR DESCRIPTION
Jira: Came up in context of pastebin & mozmoderator helm charts

What this PR does:

* changes mozmoderator maintainers to just say Web SRE team & include the it-sre@mozilla.com email - breaking into multiple PRs bc all the charts updated at once broke Travis (again).
* removes dev.sh args from deployment (runs with logs showing in container as opposed to wsgi)
