### PR TITLE
remove references to MOZILLA_API variables, uptick moderator chart

### DIFF
--- a/charts/mozmoderator/Chart.yaml
+++ b/charts/mozmoderator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mozmoderator
 description: A Helm Chart for Mozilla's Moderator application
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: c285426edacb3a1791bab84f64c16d00e6d865eb
 keywords:
   - Mozilla

--- a/charts/mozmoderator/README.md
+++ b/charts/mozmoderator/README.md
@@ -10,7 +10,8 @@ Current chart version is `0.2.0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://kubernetes-charts.storage.googleapis.com | mysql | 1.6.4 |
+| https://charts.jetstack.io | cert-manager | v1.4.0 |
+| https://charts.bitnami.com/bitnami | mysql | 8.7.1 |
 
 ## Chart Values
 

--- a/charts/mozmoderator/ci/test-values.yaml
+++ b/charts/mozmoderator/ci/test-values.yaml
@@ -7,7 +7,6 @@ configMap:
     AWS_ACCESS_KEY: testkey
     AWS_SECRET_ACCESS_KEY: testkey
     DATABASE_URL: mysql://moderator:default-non-secure-password@moderator-db-headless:3306/moderator
-    MOZILLIANS_API_KEY: testkey
     OIDC_RP_CLIENT_ID: testid
     OIDC_RP_CLIENT_SECRET: testkey
     SECRET_KEY: mymoderatorsecretkey

--- a/charts/mozmoderator/values.yaml
+++ b/charts/mozmoderator/values.yaml
@@ -70,7 +70,7 @@ externalSecrets:
 image:
   pullPolicy: IfNotPresent
   repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/moderator
-  tag: c285426edacb3a1791bab84f64c16d00e6d865eb
+  tag: bbae8c1be8431ace923c58caac928917fc2aa31e
 
 imagePullSecrets: []
 

--- a/charts/mozmoderator/values.yaml
+++ b/charts/mozmoderator/values.yaml
@@ -55,15 +55,6 @@ externalSecrets:
   #   name: DATABASE_URL
   #   property: database_url
   # - key: /{env}/moderator/envvar
-  #   name: MOZILLIANS_API_APPNAME
-  #   property: mozillians_api_appname
-  # - key: /{env}/moderator/envvar
-  #   name: MOZILLIANS_API_KEY
-  #   property: mozillians_api_key
-  # - key: /{env}/moderator/envvar
-  #   name: MOZILLIANS_API_APPNAME
-  #   property: mozillians_api_appname
-  # - key: /{env}/moderator/envvar
   #   name: OIDC_RP_CLIENT_ID
   #   property: oidc_rp_client_id
   # - key: /{env}/moderator/envvar


### PR DESCRIPTION
Jira: none, came up in context of https://mozilla-hub.atlassian.net/browse/SE-2166

What this PR does:
* Upticks Moderator Chart version to make CI happy (we use a very opinionated tool for Helm Chart ci - https://github.com/helm/chart-testing - that expects chart version upticks whenever changes occur to a chart)
* removes comment references to expected MOZILLIANS_API_* secrets available in the chart runtime (these comments are left to help guide leave breadcrumbs for the state of secrets)
* removes MOZILLIANS_API_* configMap variables for the CI test-values.yaml
* updates default image tag for deployment to commit / tag ﻿﻿bbae8c1be8431ace923c58caac928917fc2aa31e (what is used in current production)
