### PR TITLE
remove codeowners from helm charts repo

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @mozilla-it/it-se


### PR DESCRIPTION
Jira: none, came up in context of other PRs

What this PR does:
* removes CodeOwners file, which was causing @mozilla-it/it-se (or a random member of that team) to appear as a reviewer on helm chart PRs even if deselected in PR creation
* IT-SE has a lot of people on it that don't interact with helm charts, and there are new folks (@mozilla-it/sumo-devs) starting to at least review work here more that aren't on IT-SE team, so seems best to me to just remove it