### PR TITLE
add imagePullSecrets in common voice web deploy template

### DIFF
--- a/charts/mozilla-common-voice/Chart.yaml
+++ b/charts/mozilla-common-voice/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mozilla-common-voice
 icon: https://voice.mozilla.org/dist/f01895c77138837851f87c2e40acbd58.svg
-version: 0.4.4
+version: 0.4.5
 description: Deploy Mozilla Common Voice web application
 type: application
 keywords:

--- a/charts/mozilla-common-voice/templates/deployment.yaml
+++ b/charts/mozilla-common-voice/templates/deployment.yaml
@@ -3,10 +3,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.voice_web.deployment_name }}
-{{- if .Values.voice_web.extra_annotations }}
+  {{- if .Values.voice_web.extra_annotations }}
   annotations:
-  {{ toYaml .Values.voice_web.extra_annotations | nindent 4 }}
-{{- end }}
+    {{ toYaml .Values.voice_web.extra_annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -66,6 +66,10 @@ spec:
 {{- if .Values.voice_web.extra_containers }}
       {{- toYaml .Values.voice_web.extra_containers | nindent 6 }}
 {{- end }}
+      {{- with .Values.voice_web.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       - name: logs
         emptyDir: {}

--- a/charts/mozilla-common-voice/values.yaml
+++ b/charts/mozilla-common-voice/values.yaml
@@ -25,6 +25,8 @@ voice_web:
 
   image: "mozilla/commonvoice:stage-latest"
 
+  imagePullSecrets: []
+
   service_account:
     annotations: {}
 


### PR DESCRIPTION
Jira ticket: https://mozilla-hub.atlassian.net/browse/SE-2416

What this PR does:
- adds imagePullSecrets secret field to common voice web deployment template
- can create docker secret in k8s out of band, this is a (harmless) temporary measure to test a hypothesis around flux docker image pull failures