### PR TITLE
update discourse helm chart to not use kubeiam arn-role annotation

### DIFF
--- a/charts/discourse/Chart.yaml
+++ b/charts/discourse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: discourse
 description: A Helm Chart for Mozilla's Discourse application
 type: application
-version: 0.0.1
+version: 1.0.0
 appVersion: f58ded6
 keywords:
   - Mozilla

--- a/charts/discourse/templates/deployment.yaml
+++ b/charts/discourse/templates/deployment.yaml
@@ -25,7 +25,6 @@ spec:
         prometheus.io/port: {{ .Values.metrics.port | quote }}
         prometheus.io/scrape: "true"
       {{- end }}
-        iam.amazonaws.com/role: {{ .Values.deployment.arn_role }}
       labels:
         {{- include "discourse.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/discourse/values.yaml
+++ b/charts/discourse/values.yaml
@@ -40,11 +40,6 @@ db:
 
 deployment:
   annotations: {}
-  # # stage
-  # arn_role: arn:aws:iam::783633885093:role/discourse/discourse-stage
-  # # prod
-  # arn_role: arn:aws:iam::783633885093:role/discourse/discourse-prod
-  arn_role: arn:aws:iam::783633885093:role/discourse/discourse-dev
   labels: {}
   name: discourse
   replicaCount: 1


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-2169

What this PR does:
* Removes `iam.amazonaws.com/role` value from the Discourse application helm chart
* we're doing this because it expects kube2iam, which isn't a given on new EKS clusters