### PR TITLE
helm charts for oidc-gateway & etherpad

### DIFF
--- a/charts/etherpad/.helmignore
+++ b/charts/etherpad/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/etherpad/Chart.lock
+++ b/charts/etherpad/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v1.4.0
+- name: mysql
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.7.1
+digest: sha256:e93fb4a8c0549f951fbccaa5ee25474c43f8b59f33f910db6605a0479c52ed1d
+generated: "2021-08-30T20:14:20.265231-04:00"

--- a/charts/etherpad/Chart.yaml
+++ b/charts/etherpad/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: etherpad
+description: A Helm chart for the Mozilla Etherpad application
+type: application
+version: 1.0.0
+
+keywords:
+  - Mozilla
+  - etherpad
+  - pad
+
+home: https://github.com/mozilla-it/etherpad-docker
+sources:
+  - https://github.com/mozilla-it/etherpad-docker
+
+maintainers:
+  - name: Web SRE Team
+    email: it-sre@mozilla.com
+
+dependencies:
+- name: cert-manager
+  version: v1.4.0
+  condition: cert-manager.install
+  repository: https://charts.jetstack.io
+- name: mysql
+  version: 8.7.1
+  condition: mysql.install
+  repository: https://charts.bitnami.com/bitnami

--- a/charts/etherpad/ci/test-values.yaml
+++ b/charts/etherpad/ci/test-values.yaml
@@ -1,0 +1,45 @@
+cert-manager:
+  install: true
+
+configMap:
+  data:
+    ADMIN_PASSWORD: dumbetherpadpassword
+    DB_HOST: etherpad-db-headless
+    DB_NAME: etherpad
+    DB_PASS: default-non-secure-password
+    DB_USER: etherpad
+    ETHERPAD_API_KEY: dumberetherpadapikey
+    ETHERPAD_SESSION_KEY: dumbetherpadsecretkey
+
+image:
+  tag: stg-9922b5f
+
+imagePullSecrets:
+  - name: ecr-registry
+
+ingress:
+  hosts:
+    - host: pad.allizom.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          serviceName: etherpad
+          servicePort: 80
+  le:
+    name: stage
+    issuer_create: false
+
+mysql:
+  fullnameOverride: etherpad-db
+  install: true
+  auth:
+    username: etherpad
+    database: etherpad
+    password: default-non-secure-password
+    rootPassword: default-non-secure-root-password
+  image:
+    tag: 5.7.33
+  primary:
+    fullname: etherpad
+    persistence:
+      enabled: false

--- a/charts/etherpad/templates/_helpers.tpl
+++ b/charts/etherpad/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "etherpad.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "etherpad.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "etherpad.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "etherpad.labels" -}}
+helm.sh/chart: {{ include "etherpad.chart" . }}
+{{ include "etherpad.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "etherpad.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "etherpad.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/etherpad/templates/configmap.yaml
+++ b/charts/etherpad/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.configMap.name }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "etherpad.labels" . | nindent 4 }}
+    {{- with .Values.configMap.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  {{- with .Values.configMap.data }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/etherpad/templates/deployment.yaml
+++ b/charts/etherpad/templates/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.deployment.name }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "etherpad.labels" . | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "etherpad.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "etherpad.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Values.deployment.name }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.deployment.name }}
+          {{- if .Values.externalSecrets.enabled }}
+            - secretRef:
+                name: {{ .Values.deployment.name }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          ports:
+            - containerPort: {{ .Values.deployment.port }}
+              name: http
+              protocol: TCP
+          readinessProbe:
+            initialDelaySeconds: 5
+            successThreshold: 3
+            httpGet:
+              path: /
+              port: http
+          {{- with .Values.deployment.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.externalSecrets.enabled }}
+          volumeMounts:
+            - mountPath: /opt/etherpad-lite/APIKEY.txt
+              subPath: APIKEY.txt
+              name: apikey
+              readOnly: true
+            - mountPath: /opt/etherpad-lite/SESSIONKEY.txt
+              subPath: SESSIONKEY.txt
+              name: sessionkey
+              readOnly: true
+          {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.externalSecrets.enabled }}
+      volumes:
+        - name: apikey
+          secret:
+            secretName: {{ .Values.deployment.name }}
+            items:
+              - key: ETHERPAD_API_KEY
+                path: APIKEY.txt
+        - name: sessionkey
+          secret:
+            secretName: {{ .Values.deployment.name }}
+            items:
+              - key: ETHERPAD_SESSION_KEY
+                path: SESSIONKEY.txt
+      {{- end }}

--- a/charts/etherpad/templates/ingress.yaml
+++ b/charts/etherpad/templates/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}
+  annotations:
+    cert-manager.io/issuer: letsencrypt
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Frame-Options: SAMEORIGIN";
+      more_set_headers "Content-Security-Policy: frame-ancestors 'none'";
+  labels:
+    {{- include "etherpad.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ .serviceName }}
+                port:
+                  number: {{ .servicePort }}
+              {{- else }}
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}

--- a/charts/etherpad/templates/issuer.yaml
+++ b/charts/etherpad/templates/issuer.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.ingress.le.issuer_create }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: it-se@mozilla.com
+    server: {{ if eq .Values.ingress.le.name "prod" }}{{ .Values.ingress.le.prod }}{{ else }}{{ .Values.ingress.le.stage }}{{ end }}
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+{{- end }}

--- a/charts/etherpad/templates/job.yaml
+++ b/charts/etherpad/templates/job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ .Values.job.name }}
+  {{- with .Values.job.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "etherpad.labels" . | nindent 4 }}
+    {{- with .Values.job.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  schedule: "{{ .Values.job.schedule }}"
+  successfulJobsHistoryLimit: {{ .Values.job.successfulJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: {{ .Values.job.name }}
+              command:
+                - /bin/bash
+                - etherpad-manage.sh
+              envFrom:
+                - configMapRef:
+                    name: {{ .Values.deployment.name }}
+                {{- if .Values.externalSecrets.enabled }}
+                - secretRef:
+                    name: {{ .Values.deployment.name }}
+                {{- end }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              {{- with .Values.job.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          restartPolicy: Never

--- a/charts/etherpad/templates/secrets.yaml
+++ b/charts/etherpad/templates/secrets.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.externalSecrets.enabled -}}
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.externalSecrets.name }}
+  {{- with .Values.externalSecrets.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "etherpad.labels" . | nindent 4 }}
+    {{- with .Values.externalSecrets.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backendType: secretsManager
+  data:
+    {{- with .Values.externalSecrets.secrets }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  template:
+    metadata:
+      {{- with .Values.externalSecrets.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "etherpad.labels" . | nindent 8 }}
+        {{- with .Values.externalSecrets.labels }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+{{- end }}

--- a/charts/etherpad/templates/service.yaml
+++ b/charts/etherpad/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etherpad
+  labels:
+    {{- include "etherpad.labels" . | nindent 4 }}
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: {{ .Values.deployment.port }}
+  selector:
+    {{- include "etherpad.selectorLabels" . | nindent 4 }}
+  type: NodePort

--- a/charts/etherpad/templates/tests/test-connection.yaml
+++ b/charts/etherpad/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "etherpad.fullname" . }}-test-connection"
+  labels:
+    {{- include "etherpad.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: curl
+      image: curlimages/curl
+      command: ['curl']
+      args: ['-L', 'etherpad:80']
+  restartPolicy: Never

--- a/charts/etherpad/values.yaml
+++ b/charts/etherpad/values.yaml
@@ -1,0 +1,108 @@
+cert-manager:
+  install: false
+
+configMap:
+  annotations: {}
+  data:
+    DB_CHARSET: utf8mb4
+    DB_PORT: "3306"
+    DB_TYPE: mysql
+    PORT: "9000"
+    TITLE: Etherpad
+  labels: {}
+  name: etherpad
+
+deployment:
+  annotations: {}
+  labels: {}
+  name: etherpad
+  port: "9000"
+  replicaCount: 1
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+
+externalSecrets:
+  annotations: {}
+  enabled: false
+  labels: {}
+  name: etherpad
+  # Values.externalSecrets.secrets are for external-secrets key, name, properties
+  # For local environments, don't enabled externalSecrets & use the configMap block
+  secrets: []
+  # - key: /{env}/etherpad/envvar
+  #   name: ADMIN_PASSWORD
+  #   property: ADMIN_PASSWORD
+  # - key: /{env}/etherpad/envvar
+  #   name: DB_HOST
+  #   property: DB_HOST
+  # - key: /{env}/etherpad/envvar
+  #   name: DB_NAME
+  #   property: DB_NAME
+  # - key: /{env}/etherpad/envvar
+  #   name: DB_PASS
+  #   property: DB_PASS
+  # - key: /{env}/etherpad/envvar
+  #   name: DB_USER
+  #   property: DB_USER
+  # - key: /{env}/etherpad/envvar
+  #   name: ETHERPAD_API_KEY
+  #   property: ETHERPAD_API_KEY
+  # - key: /{env}/etherpad/envvar
+  #   name: ETHERPAD_SESSION_KEY
+  #   property: ETHERPAD_SESSION_KEY
+
+image:
+  pullPolicy: Always
+  repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/etherpad
+  tag: v0.0.1
+
+imagePullSecrets: []
+
+ingress:
+  className: "nginx"
+  hosts:
+    - host: pad.allizom.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          serviceName: oidc-gateway  # service created by oidc-gateway helm dependency
+          servicePort: 80
+  labels: {}
+  le:
+    create: false
+    issuer_create: true
+    name: stage
+    prod: https://acme-v02.api.letsencrypt.org/directory
+    stage: https://acme-staging-v02.api.letsencrypt.org/directory
+  name: etherpad
+  tls:
+    - hosts:
+        - pad.allizom.org
+      secretName: chart-pad-allizom-org
+
+job:
+  annotations: {}
+  labels: {}
+  name: etherpad-manager
+  resources:
+    requests:
+      cpu: 500m
+      memory: 1Gi
+    limits:
+      cpu: 1
+      memory: 2Gi
+  schedule: "@hourly"
+  successfulJobsHistoryLimit: 3
+
+metrics:
+  enabled: false
+
+mysql:
+  install: false
+  image:
+    tag: 5.7.33

--- a/charts/oidc-gateway/.helmignore
+++ b/charts/oidc-gateway/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/oidc-gateway/Chart.yaml
+++ b/charts/oidc-gateway/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+description: A Helm chart for OIDC Gateway workload to put in front of workloads that require an authentication layer.
+name: oidc-gateway
+version: 1.0.0
+
+keywords:
+  - Mozilla
+  - oidc
+
+sources:
+  - https://github.com/mozilla-services/oidc-gateway
+
+maintainers:
+  - name: Web SRE Team
+    email: it-sre@mozilla.com

--- a/charts/oidc-gateway/README.md
+++ b/charts/oidc-gateway/README.md
@@ -1,0 +1,3 @@
+# OIDC Gateway
+
+Packaged helm-chart for https://github.com/mozilla-services/oidc-gateway.

--- a/charts/oidc-gateway/ci/test-values.yaml
+++ b/charts/oidc-gateway/ci/test-values.yaml
@@ -1,0 +1,8 @@
+configMap:
+  data:
+    oidc:
+      client_id: sample_client_id
+      client_secret: secret_value_if_not_using_externalSecrets
+      discovery: 'https://auth.mozilla.auth0.com/.well-known/openid-configuration'
+    session_secret: secret_value_if_not_using_externalSecrets
+    upstream: oidc-gateway

--- a/charts/oidc-gateway/templates/NOTES.txt
+++ b/charts/oidc-gateway/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ . }}{{ $.Values.ingress.path }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "oidc-gateway.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "oidc-gateway.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "oidc-gateway.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "oidc-gateway.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/charts/oidc-gateway/templates/_helpers.tpl
+++ b/charts/oidc-gateway/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "oidc-gateway.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "oidc-gateway.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "oidc-gateway.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "oidc-gateway.labels" -}}
+helm.sh/chart: {{ include "oidc-gateway.chart" . }}
+{{ include "oidc-gateway.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "oidc-gateway.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oidc-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "oidc-gateway.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "oidc-gateway.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/oidc-gateway/templates/configmap.yaml
+++ b/charts/oidc-gateway/templates/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.configMap.name }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "oidc-gateway.labels" . | nindent 4 }}
+    {{- with .Values.configMap.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  config.yaml: |
+    {{- with .Values.configMap.data }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}    

--- a/charts/oidc-gateway/templates/deployment.yaml
+++ b/charts/oidc-gateway/templates/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.deployment.name }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "oidc-gateway.labels" . | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  # Currently limited to one replica due to using NGINX local cache
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "oidc-gateway.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "oidc-gateway.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Values.deployment.name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /app/config.yaml
+              subPath: config.yaml
+              name: config
+            {{- if .Values.externalSecrets.enabled }}
+            - mountPath: /app/secrets.yaml
+              subPath: secrets.yaml
+              name: secrets
+            {{- end }}
+          {{- with .Values.deployment.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{ toYaml . | indent 8 }}
+      {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Values.configMap.name }}
+        {{- if .Values.externalSecrets.enabled }}
+        - name: secrets
+          secret:
+            secretName: {{ .Values.externalSecrets.name }}
+        {{- end }}

--- a/charts/oidc-gateway/templates/ingress.yaml
+++ b/charts/oidc-gateway/templates/ingress.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.ingress.enabled -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}
+  annotations:
+    cert-manager.io/issuer: letsencrypt
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Frame-Options: SAMEORIGIN";
+      more_set_headers "Content-Security-Policy: frame-ancestors 'none'";
+  labels:
+    {{- include "etherpad.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ .serviceName }}
+                port:
+                  number: {{ .servicePort }}
+              {{- else }}
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/oidc-gateway/templates/secrets.yaml
+++ b/charts/oidc-gateway/templates/secrets.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.externalSecrets.enabled -}}
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.externalSecrets.name }}
+  {{- with .Values.externalSecrets.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "oidc-gateway.labels" . | nindent 4 }}
+    {{- with .Values.externalSecrets.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backendType: secretsManager
+  data:
+    - key: /{{ .Values.externalSecrets.secretPath }}/oidc-gateway-secrets
+      name: secrets.yaml
+  template:
+    metadata:
+      {{- with .Values.externalSecrets.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "oidc-gateway.labels" . | nindent 8 }}
+        {{- with .Values.externalSecrets.labels }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+{{- end }}

--- a/charts/oidc-gateway/templates/service.yaml
+++ b/charts/oidc-gateway/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: oidc-gateway
+  labels:
+    {{- include "oidc-gateway.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      protocol: TCP
+      targetPort: http
+  selector:
+    {{- include "oidc-gateway.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}

--- a/charts/oidc-gateway/values.yaml
+++ b/charts/oidc-gateway/values.yaml
@@ -1,0 +1,64 @@
+affinity: {}
+
+configMap:
+  annotations: {}
+  data:
+    oidc:
+      client_id: sample_client_id
+      # client_secret: secret_value_if_not_using_externalSecrets
+      discovery: 'https://auth.mozilla.auth0.com/.well-known/openid-configuration'
+    # session_secret: secret_value_if_not_using_externalSecrets
+    upstream: upstream-svc  # populated by service behind the oidc-gateway
+  labels: {}
+  name: oidc-gateway
+
+deployment:
+  annotations: {}
+  labels: {}
+  name: oidc-gateway
+  replicaCount: 1
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+externalSecrets:
+  annotations: {}
+  enabled: false
+  secretPath: 'dev/upstream-app'  # populated by service behind the oidc-gateway
+  labels: {}
+  name: oidc-gateway
+  # structure: { "oidc": { "client_secret": "secret key for oidc client"}, "session_secret": "oidc session secret" }
+
+image:
+  pullPolicy: IfNotPresent
+  repository: mozilla/oidc-gateway
+  tag: latest
+
+ingress:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+  enabled: false
+  hosts:
+    - chart-example.local
+  path: /
+  tls:
+    - hosts:
+        - chart-example.local
+      secretName: chart-example-tls
+
+nodeSelector: {}
+
+service:
+  type: ClusterIP
+  port: 80
+
+tolerations: []


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-1151

What this PR does:
* Creates a Helm Chart for oidc-gateway (see https://github.com/mozilla-services/oidc-gateway), used by Etherpad but deployed manually using helm v1 template before
* Creates a Helm Chart for Etherpad, which expects in our implementation (but doesn't explicitly require as a dependency) oidc-gateway