### PR TITLE
initial commit of careers

### DIFF
--- a/charts/careers/.helmignore
+++ b/charts/careers/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/careers/Chart.yaml
+++ b/charts/careers/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: careers
+description: A Helm chart for Mozilla's careers page, careers.mozilla.org
+
+type: application
+
+version: 0.0.1

--- a/charts/careers/ci/test-values.yaml
+++ b/charts/careers/ci/test-values.yaml
@@ -1,0 +1,6 @@
+imagePullSecrets:
+  - name: ecr-registry
+
+image:
+  repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/careers
+  tag: "v2.0.0"

--- a/charts/careers/ci/test-values.yaml
+++ b/charts/careers/ci/test-values.yaml
@@ -3,4 +3,4 @@ imagePullSecrets:
 
 image:
   repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/careers
-  tag: "v2.0.0"
+  tag: "stg-91980d9b"

--- a/charts/careers/templates/NOTES.txt
+++ b/charts/careers/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. check that the application deployed well by running the following commands
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  curl https://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "careers.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "careers.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "careers.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "careers.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/careers/templates/_helpers.tpl
+++ b/charts/careers/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "careers.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "careers.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "careers.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "careers.labels" -}}
+helm.sh/chart: {{ include "careers.chart" . }}
+{{ include "careers.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "careers.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "careers.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "careers.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "careers.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/careers/templates/configmap.yaml
+++ b/charts/careers/templates/configmap.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/careers/templates/configmap.yaml
+++ b/charts/careers/templates/configmap.yaml
@@ -3,4 +3,5 @@ kind: ConfigMap
 metadata:
   name: {{ include "careers.fullname" . }}
 data:
-  DJANGO_ALLOWED_HOSTS: {{ .Values.configMap.allowedHosts }}
+  ALLOWED_HOSTS: {{ .Values.configMap.allowedHosts }}
+  DEBUG: "True"

--- a/charts/careers/templates/configmap.yaml
+++ b/charts/careers/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "careers.fullname" . }}
+data:
+  DJANGO_ALLOWED_HOSTS: {{ .Values.configMap.allowedHosts }}

--- a/charts/careers/templates/db-migration.yaml
+++ b/charts/careers/templates/db-migration.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "careers.fullname" . }}
+  labels:
+    {{- include "careers.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Never
+      containers:
+      - name: {{ .Chart.Name }}-db-migration
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        command: ["python", "manage.py", "migrate", "--noinput"]
+        envFrom:
+          - secretRef:
+              name: {{ include "careers.fullname" . }}-hook

--- a/charts/careers/templates/hpa.yaml
+++ b/charts/careers/templates/hpa.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
+---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/careers/templates/hpa.yaml
+++ b/charts/careers/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "careers.fullname" . }}
+  labels:
+    {{- include "careers.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "careers.fullname" . }}-web
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/careers/templates/ingress.yaml
+++ b/charts/careers/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "careers.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "careers.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/careers/templates/periodic_job.yaml
+++ b/charts/careers/templates/periodic_job.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:

--- a/charts/careers/templates/periodic_job.yaml
+++ b/charts/careers/templates/periodic_job.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ include "careers.fullname" . }}

--- a/charts/careers/templates/periodic_job.yaml
+++ b/charts/careers/templates/periodic_job.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "careers.fullname" . }}
+  labels:
+    {{- include "careers.labels" . | nindent 4 }}
+spec:
+  schedule: "*/15 * * * *"
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: "{{ .Chart.Name }}-periodic"
+            image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+            imagePullPolicy: IfNotPresent
+            envFrom:
+            - configMapRef:
+                name: {{ include "careers.fullname" . }}
+            - secretRef:
+                name: {{ include "careers.fullname" . }}
+            command: ["/app/scripts/sync.sh"]

--- a/charts/careers/templates/secrets.yaml
+++ b/charts/careers/templates/secrets.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.externalSecrets.enabled -}}
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "careers.fullname" . }}
+spec:
+  backendType: secretsManager
+  dataFrom:
+  - {{ .Values.externalSecrets.secretName }}
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "careers.fullname" . }}-hook
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backendType: secretsManager
+  dataFrom:
+  - {{ .Values.externalSecrets.secretName }}
+{{- else }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "careers.fullname" . }}
+data:
+  PG_NAME: Y2FyZWVycw==
+  PG_USER: Y2FyZWVycw==
+  PG_PASSWORD: ZGVmYXVsdHBhc3N3b3Jk
+  PG_HOST: cG9zdGdyZXM=
+  PG_PORT: NTQzMg==
+  SECRET_KEY: dGhpcy1pcy1ub3QtdGhlLXByb2R1Y3Rpb24tdmFsdWU=
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "careers.fullname" . }}-hook
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": hook-succeeded
+data:
+  PG_NAME: Y2FyZWVycw==
+  PG_USER: Y2FyZWVycw==
+  PG_PASSWORD: ZGVmYXVsdHBhc3N3b3Jk
+  PG_HOST: cG9zdGdyZXM=
+  PG_PORT: NTQzMg==
+  SECRET_KEY: dGhpcy1pcy1ub3QtdGhlLXByb2R1Y3Rpb24tdmFsdWU=
+{{- end }}
+

--- a/charts/careers/templates/secrets.yaml
+++ b/charts/careers/templates/secrets.yaml
@@ -52,4 +52,3 @@ data:
   DEBUG: RmFsc2U=
   ALLOWED_HOSTS: Kg==
 {{- end }}
-

--- a/charts/careers/templates/secrets.yaml
+++ b/charts/careers/templates/secrets.yaml
@@ -29,9 +29,10 @@ data:
   PG_NAME: Y2FyZWVycw==
   PG_USER: Y2FyZWVycw==
   PG_PASSWORD: ZGVmYXVsdHBhc3N3b3Jk
-  PG_HOST: cG9zdGdyZXM=
+  PG_HOST: Y2FyZWVycy1wc3Fs
   PG_PORT: NTQzMg==
   SECRET_KEY: dGhpcy1pcy1ub3QtdGhlLXByb2R1Y3Rpb24tdmFsdWU=
+  DMS: aHR0cHM6Ly93ZWJob29rLnNpdGUvMTUzY2U3MmMtOGI1Zi00YTNhLTg5ZGUtNzY2YzlmMTY1Y2Q1
 ---
 apiVersion: v1
 kind: Secret
@@ -45,8 +46,10 @@ data:
   PG_NAME: Y2FyZWVycw==
   PG_USER: Y2FyZWVycw==
   PG_PASSWORD: ZGVmYXVsdHBhc3N3b3Jk
-  PG_HOST: cG9zdGdyZXM=
+  PG_HOST: Y2FyZWVycy1wc3Fs
   PG_PORT: NTQzMg==
   SECRET_KEY: dGhpcy1pcy1ub3QtdGhlLXByb2R1Y3Rpb24tdmFsdWU=
+  DEBUG: RmFsc2U=
+  ALLOWED_HOSTS: Kg==
 {{- end }}
 

--- a/charts/careers/templates/service.yaml
+++ b/charts/careers/templates/service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/careers/templates/service.yaml
+++ b/charts/careers/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "careers.fullname" . }}
+  labels:
+    {{- include "careers.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/component: web
+    {{- include "careers.selectorLabels" . | nindent 4 }}

--- a/charts/careers/templates/serviceaccount.yaml
+++ b/charts/careers/templates/serviceaccount.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/careers/templates/serviceaccount.yaml
+++ b/charts/careers/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "careers.serviceAccountName" . }}
+  labels:
+    {{- include "careers.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/careers/templates/tests/test-connection.yaml
+++ b/charts/careers/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "careers.fullname" . }}-test-connection"
+  labels:
+    {{- include "careers.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: curl
+      image: curlimages/curl
+      command: ['curl']
+      args: ['-L', '{{ include "careers.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/careers/templates/web_deployment.yaml
+++ b/charts/careers/templates/web_deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/careers/templates/web_deployment.yaml
+++ b/charts/careers/templates/web_deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "careers.fullname" . }}-web
+  labels:
+    app.kubernetes.io/component: web
+    {{- include "careers.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: web
+      {{- include "careers.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/component: web
+        {{- include "careers.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "careers.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /__lbheartbeat__
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /__lbheartbeat__
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+          - configMapRef:
+              name: {{ include "careers.fullname" . }}
+          - secretRef:
+              name: {{ include "careers.fullname" . }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/careers/templates/web_deployment.yaml
+++ b/charts/careers/templates/web_deployment.yaml
@@ -36,6 +36,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["python", "manage.py", "runserver", "0.0.0.0:8000"]
           ports:
             - name: http
               containerPort: 8000

--- a/charts/careers/values.yaml
+++ b/charts/careers/values.yaml
@@ -1,0 +1,65 @@
+# Default values for careers.
+replicaCount: 1
+
+# this is special helm operator magic, image.tag can be kept up to date with the automated image deploys
+image:
+  repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/careers
+  pullPolicy: IfNotPresent
+  tag: "v2.0.0"
+
+fullnameOverride: "careers"
+
+serviceAccount:
+  create: true
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+  hosts:
+    - host: careers.mozilla.org
+      paths:
+        - path: /
+      backend:
+        serviceName: careers
+        servicePort: 80
+
+resources:
+  limits:
+    cpu: 1000m
+    memory: 2048Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+  targetMemoryUtilizationPercentage: 70
+
+configMap:
+  allowedHosts: '"*"'
+
+externalSecrets:
+  enabled: false
+  secretName: ""
+
+imagePullSecrets: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+podAnnotations:
+  "prometheus.io/scrape": "false"
+
+securityContext: {}
+nameOverride: ""

--- a/charts/careers/values.yaml
+++ b/charts/careers/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/careers
   pullPolicy: IfNotPresent
-  tag: "v2.0.0"
+  tag: "stg-91980d9b"
 
 fullnameOverride: "careers"
 

--- a/ci/deps/careers/install.sh
+++ b/ci/deps/careers/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update
+
+readonly NAMESPACE="chart-ci-e2e"
+
+
+
+helm upgrade --install \
+  --version 10.4.2 \
+  --namespace $NAMESPACE \
+  --set postgresqlPassword=defaultpassword \
+  --set postgresqlUsername=careers \
+  --set postgresqlDatabase=careers \
+  --set fullnameOverride=postgres \
+  postgresql bitnami/postgresql

--- a/ci/deps/careers/install.sh
+++ b/ci/deps/careers/install.sh
@@ -15,5 +15,5 @@ helm upgrade --install \
   --set postgresqlPassword=defaultpassword \
   --set postgresqlUsername=careers \
   --set postgresqlDatabase=careers \
-  --set fullnameOverride=postgres \
-  postgresql bitnami/postgresql
+  --set fullnameOverride=careers-psql \
+  careers-psql bitnami/postgresql


### PR DESCRIPTION
Initial helm chart for careers
DB migration as preinstall hook
then generates a webdeployment, with service and nginx ingress to server the traffic
also creates a cronjob, to pull job data from greenhouse and push the static version of the website to s3 as well