### PR TITLE
first pass of securitywiki helm chart

### DIFF
--- a/charts/securitywiki/.helmignore
+++ b/charts/securitywiki/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/securitywiki/Chart.lock
+++ b/charts/securitywiki/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: cert-manager
+  repository: https://charts.jetstack.io
+  version: v1.4.0
+- name: memcached
+  repository: https://charts.bitnami.com/bitnami
+  version: 5.14.2
+- name: mysql
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.7.1
+digest: sha256:97a2fe5a70960eb851df7a721c63db362f4c7e592374a8164b53fae2d1d8ce0e
+generated: "2021-09-03T18:44:32.379571-04:00"

--- a/charts/securitywiki/Chart.yaml
+++ b/charts/securitywiki/Chart.yaml
@@ -1,0 +1,32 @@
+apiVersion: v2
+name: securitywiki
+description: A Helm chart for the Mozilla Security Wiki (mediawiki) application
+type: application
+version: 0.0.1
+
+keywords:
+  - Mozilla
+  - mediawiki
+  - securitywiki
+
+home: https://github.com/mozilla-it/helm-charts
+sources:
+  - https://github.com/mozilla-it/securitywiki-docker
+
+maintainers:
+  - name: Web SRE Team
+    email: it-sre@mozilla.com
+
+dependencies:
+- name: cert-manager
+  version: v1.4.0
+  condition: cert-manager.install
+  repository: https://charts.jetstack.io
+- name: memcached
+  version: 5.14.2
+  condition: memcached.install
+  repository: https://charts.bitnami.com/bitnami
+- name: mysql
+  version: 8.7.1
+  condition: mysql.install
+  repository: https://charts.bitnami.com/bitnami

--- a/charts/securitywiki/Chart.yaml
+++ b/charts/securitywiki/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: securitywiki
 description: A Helm chart for the Mozilla Security Wiki (mediawiki) application
 type: application
-version: 0.0.1
+version: 1.0.0
 
 keywords:
   - Mozilla

--- a/charts/securitywiki/ci/test-values.yaml
+++ b/charts/securitywiki/ci/test-values.yaml
@@ -51,4 +51,4 @@ mysql:
       enabled: false
 
 volume:
-  create: false
+  enabled: false

--- a/charts/securitywiki/ci/test-values.yaml
+++ b/charts/securitywiki/ci/test-values.yaml
@@ -1,0 +1,54 @@
+cert-manager:
+  install: false
+
+configMap:
+  data:
+    ENVIRONMENT: local
+    MEMCACHED_HOST: memcached
+    MEMCACHED_PORT: "11211"
+    MYSQL_HOST: securitywiki-db-headless
+    MYSQL_DATABASE: securitywiki
+    MYSQL_PASSWORD: default-non-secure-password
+    MYSQL_PORT: "3306"
+    MYSQL_USER: securitywiki
+    SITE_URL: http://localhost
+
+deployment:
+  replicaCount: 1
+  healthchecks:
+    path: /
+
+hpa:
+  enabled: false
+
+image:
+  pullPolicy: Always
+  repository: mediawiki
+  tag: 1.31.5
+
+ingress:
+  enabled: false
+  le:
+    issuer_create: false
+
+memcached:
+  fullnameOverride: memcached
+  install: true
+
+mysql:
+  fullnameOverride: securitywiki-db
+  install: true
+  auth:
+    username: securitywiki
+    database: securitywiki
+    password: default-non-secure-password
+    rootPassword: default-non-secure-root-password
+  image:
+    tag: 5.7.33
+  primary:
+    fullname: securitywiki
+    persistence:
+      enabled: false
+
+volume:
+  create: false

--- a/charts/securitywiki/templates/_helpers.tpl
+++ b/charts/securitywiki/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "securitywiki.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "securitywiki.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "securitywiki.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "securitywiki.labels" -}}
+helm.sh/chart: {{ include "securitywiki.chart" . }}
+{{ include "securitywiki.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "securitywiki.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "securitywiki.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/securitywiki/templates/configmap.yaml
+++ b/charts/securitywiki/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.configMap.name }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "securitywiki.labels" . | nindent 4 }}
+    {{- with .Values.configMap.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  {{- with .Values.configMap.data }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/charts/securitywiki/templates/deployment.yaml
+++ b/charts/securitywiki/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-      {{- if .Values.volume.create }}
+      {{- if .Values.volume.enabled }}
         - name: securitywiki-fs
           persistentVolumeClaim:
             claimName: securitywiki-shared

--- a/charts/securitywiki/templates/deployment.yaml
+++ b/charts/securitywiki/templates/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.deployment.name }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "securitywiki.labels" . | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "securitywiki.selectorLabels" . | nindent 6 }}
+  strategy:
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: "25%"
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{- include "securitywiki.selectorLabels" . | nindent 8 }}
+    spec:
+      initContainers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - "/bin/bash"
+            - "-c"
+            - "chown www-data:www-data /data/securitywiki && find /data/securitywiki \\! -user www-data -exec chown -R www-data:www-data {} \\;"
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: "128m"
+            limits:
+              memory: 128Mi
+              cpu: "128m"
+          volumeMounts:
+            - name: securitywiki-fs
+              mountPath: /data/securitywiki
+      containers:
+        - name: {{ .Values.deployment.name }}
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.deployment.name }}
+          {{- if .Values.externalSecrets.enabled }}
+            - secretRef:
+                name: {{ .Values.deployment.name }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.deployment.healthchecks.path }}
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 5
+            successThreshold: 3
+            httpGet:
+              path: {{ .Values.deployment.healthchecks.path }}
+              port: http
+          {{- with .Values.deployment.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: securitywiki-fs
+              mountPath: /data/securitywiki
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+      {{- if .Values.volume.create }}
+        - name: securitywiki-fs
+          persistentVolumeClaim:
+            claimName: securitywiki-shared
+      {{- else }}
+        - name: securitywiki-fs
+          emptyDir: {}
+      {{- end }}

--- a/charts/securitywiki/templates/hpa.yaml
+++ b/charts/securitywiki/templates/hpa.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: securitywiki
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "securitywiki.labels" . | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.deployment.name }}
+  targetCPUUtilizationPercentage: 80
+{{- end }}

--- a/charts/securitywiki/templates/ingress.yaml
+++ b/charts/securitywiki/templates/ingress.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.ingress.enabled }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ .Values.ingress.name }}
+  annotations:
+    cert-manager.io/issuer: letsencrypt
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      more_set_headers "X-Frame-Options: SAMEORIGIN";
+      more_set_headers "Content-Security-Policy: frame-ancestors 'none'";
+  labels:
+    {{- include "securitywiki.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ .serviceName }}
+                port:
+                  number: {{ .servicePort }}
+              {{- else }}
+              serviceName: {{ .serviceName }}
+              servicePort: {{ .servicePort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/securitywiki/templates/issuer.yaml
+++ b/charts/securitywiki/templates/issuer.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.ingress.le.issuer_create }}
+apiVersion: cert-manager.io/v1alpha2
+kind: Issuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: it-se@mozilla.com
+    server: {{ if eq .Values.ingress.le.name "prod" }}{{ .Values.ingress.le.prod }}{{ else }}{{ .Values.ingress.le.stage }}{{ end }}
+    privateKeySecretRef:
+      name: letsencrypt
+    solvers:
+      - http01:
+          ingress:
+            class: nginx
+{{- end }}

--- a/charts/securitywiki/templates/pv.yaml
+++ b/charts/securitywiki/templates/pv.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.volume.create }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ .Values.volume.name }}
+  {{- with .Values.volume.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "securitywiki.labels" . | nindent 4 }}
+    {{- with .Values.volume.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.volume.accessModes }}
+  capacity:
+    storage: {{ .Values.volume.capacityStorage }}
+  persistentVolumeReclaimPolicy: "Retain"
+  nfs:
+    path: "/"
+    server: {{ .Values.volume.nfsServer }}
+  storageClassName: {{ .Values.volume.storageClassName }}
+{{- end }}

--- a/charts/securitywiki/templates/pv.yaml
+++ b/charts/securitywiki/templates/pv.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.volume.create }}
+{{- if .Values.volume.enabled }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:

--- a/charts/securitywiki/templates/pvc.yaml
+++ b/charts/securitywiki/templates/pvc.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.volume.create }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: securitywiki-shared
+  {{- with .Values.volume.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "securitywiki.labels" . | nindent 4 }}
+    {{- with .Values.volume.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.volume.accessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.volume.storageRequest }}
+  volumeName: {{ .Values.volume.name }}
+  storageClassName: {{ .Values.volume.storageClassName }}
+{{- end }}

--- a/charts/securitywiki/templates/pvc.yaml
+++ b/charts/securitywiki/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.volume.create }}
+{{- if .Values.volume.enabled }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/securitywiki/templates/secrets.yaml
+++ b/charts/securitywiki/templates/secrets.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.externalSecrets.enabled -}}
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.externalSecrets.name }}
+  {{- with .Values.externalSecrets.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "securitywiki.labels" . | nindent 4 }}
+    {{- with .Values.externalSecrets.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  backendType: secretsManager
+  data:
+    {{- with .Values.externalSecrets.secrets }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  template:
+    metadata:
+      {{- with .Values.externalSecrets.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "securitywiki.labels" . | nindent 8 }}
+        {{- with .Values.externalSecrets.labels }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+{{- end }}

--- a/charts/securitywiki/templates/service.yaml
+++ b/charts/securitywiki/templates/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: securitywiki
+  labels:
+    {{- include "securitywiki.labels" . | nindent 4 }}
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+    - port: 80
+      name: http
+      targetPort: 80
+      protocol: TCP
+  selector:
+    {{- include "securitywiki.selectorLabels" . | nindent 4 }}
+  type: LoadBalancer
+{{- end }}

--- a/charts/securitywiki/templates/service.yaml
+++ b/charts/securitywiki/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
   selector:
     {{- include "securitywiki.selectorLabels" . | nindent 4 }}
   type: LoadBalancer
+{{- end }}

--- a/charts/securitywiki/templates/service.yaml
+++ b/charts/securitywiki/templates/service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.ingress.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -15,4 +14,3 @@ spec:
   selector:
     {{- include "securitywiki.selectorLabels" . | nindent 4 }}
   type: LoadBalancer
-{{- end }}

--- a/charts/securitywiki/values.yaml
+++ b/charts/securitywiki/values.yaml
@@ -1,0 +1,114 @@
+cert-manager:
+  install: false
+
+configMap:
+  annotations: {}
+  data:
+    ENVIRONMENT: stage
+    SITE_URL: https://securitywiki.allizom.org
+  labels: {}
+  name: securitywiki
+
+deployment:
+  annotations: {}
+  healthchecks:
+    path: /health.php
+  labels: {}
+  name: securitywiki
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 256m
+      memory: 256Mi
+    limits:
+      cpu: 512m
+      memory: 512Mi
+
+externalSecrets:
+  annotations: {}
+  enabled: false
+  labels: {}
+  name: securitywiki
+  # Values.externalSecrets.secrets are for external-secrets key, name, properties
+  # For local environments, don't enabled externalSecrets & use the configMap block
+  secrets: []
+  # - key: /{env}/securitywiki/envvar
+  #   name: MEMCACHED_HOST
+  #   property: MEMCACHED_HOST
+  # - key: /{env}/securitywiki/envvar
+  #   name: MEMCACHED_PORT
+  #   property: MEMCACHED_PORT
+  # - key: /{env}/securitywiki/envvar
+  #   name: MYSQL_DATABASE
+  #   property: MYSQL_DATABASE
+  # - key: /{env}/securitywiki/envvar
+  #   name: MYSQL_HOST
+  #   property: MYSQL_HOST
+  # - key: /{env}/securitywiki/envvar
+  #   name: MYSQL_PASSWORD
+  #   property: MYSQL_PASSWORD
+  # - key: /{env}/securitywiki/envvar
+  #   name: MYSQL_USER
+  #   property: MYSQL_USER
+  # - key: /{env}/securitywiki/envvar
+  #   name: OIDC_CLIENT_ID
+  #   property: OIDC_CLIENT_ID
+  # - key: /{env}/securitywiki/envvar
+  #   name: OIDC_CLIENT_SECRET
+  #   property: OIDC_CLIENT_SECRET
+  # - key: /{env}/securitywiki/envvar
+  #   name: OIDC_CRYPTO_PASSPHRASE
+  #   property: OIDC_CRYPTO_PASSPHRASE
+
+hpa:
+  enabled: true
+  maxReplicas: 4
+  minReplicas: 2
+
+image:
+  pullPolicy: Always
+  repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/securitywiki
+  tag: master-cccd24f1c4e62fef09ff2d0625f29ee91277a270
+
+imagePullSecrets: []
+
+ingress:
+  className: "nginx"
+  enabled: true
+  hosts:
+    - host: securitywiki.allizom.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          serviceName: securitywiki
+          servicePort: 80
+  labels: {}
+  le:
+    create: false
+    issuer_create: true
+    name: stage
+    prod: https://acme-v02.api.letsencrypt.org/directory
+    stage: https://acme-staging-v02.api.letsencrypt.org/directory
+  name: securitywiki
+  tls:
+    - hosts:
+        - securitywiki.allizom.com
+      secretName: chart-securitywiki-allizom-org
+
+memcached:
+  install: false
+
+mysql:
+  image:
+    tag: 5.7.33
+  install: false
+
+volume:
+  accessModes: ReadWriteMany
+  annotations: {}
+  capacityStorage: 100Gi
+  create: true
+  name: securitywiki-stage
+  nfsServer: "fs-d763987d.efs.us-west-2.amazonaws.com"
+  storageClassName: efs
+  storageRequest: 20Gi


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/SE-1153

What this PR does:
* creates a first pass of a securitywiki helm chart, with some pretty big overrides for CI to pass (biggest one of these overrides is that we can't use our securitywiki image to test the chart, since our image has Apache setup with OIDC, so the pod won't run without a valid OIDC connection - which I don't want to setup in CI).