### PR TITLE
Discourse: Add ability to pass annotations to Discourse ingress

### DIFF
--- a/charts/discourse/Chart.yaml
+++ b/charts/discourse/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: discourse
 description: A Helm Chart for Mozilla's Discourse application
 type: application
-version: 2.0.1
+version: 2.0.2
 appVersion: f58ded6
 keywords:
   - Mozilla

--- a/charts/discourse/ci/test-values.yaml
+++ b/charts/discourse/ci/test-values.yaml
@@ -31,6 +31,11 @@ imagePullSecrets:
   - name: ecr-registry
 
 ingress:
+  annotations:
+    nginx.ingress.kubernetes.io/server-snippet: |
+          location /webhooks/aws {
+            deny all;
+          }
   le:
     name: stage
     issuer_create: false

--- a/charts/discourse/templates/ingress.yaml
+++ b/charts/discourse/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "X-Frame-Options: SAMEORIGIN";
       more_set_headers "Content-Security-Policy: frame-ancestors 'none'";
+    {{- with .Values.ingress.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}    
   labels:
     {{- include "discourse.labels" . | nindent 4 }}
     {{- with .Values.ingress.labels }}

--- a/charts/discourse/values.yaml
+++ b/charts/discourse/values.yaml
@@ -113,6 +113,7 @@ image:
 imagePullSecrets: []
 
 ingress:
+  annotations: {}
   className: "nginx"
   hosts:
     - host: discourse-dev.allizom.org


### PR DESCRIPTION
Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1737346

What this PR does:
* allows annotations to be passed to ingress object
* this is so we can add an annotation to Discourse instances affected by this: https://github.com/discourse/discourse/security/advisories/GHSA-jcjx-pvpc-qgwq 
* the annotation in the CI test is what we'd use for the above (block path /webhooks/aws to all traffic)
* will test this in dev, stage deploys next then prod; it is easier than upgrading discourse at this time, as discourse upgrade was blocked some months ago by the original developer (no longer on the project) being unable to confirm the discourse plugins would work with the updated discourse application codebase