### PR TITLE
add starter helm chart for github action runners

### DIFF
--- a/charts/github-actions-runner/.helmignore
+++ b/charts/github-actions-runner/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/github-actions-runner/Chart.yaml
+++ b/charts/github-actions-runner/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: github-actions-runner
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/charts/github-actions-runner/ci/ct-values.yaml
+++ b/charts/github-actions-runner/ci/ct-values.yaml
@@ -1,0 +1,15 @@
+configMap:
+  data:
+    RUNNER_TOKEN: test
+
+deployment:
+  command:
+    - "bash"
+    - "-c"
+  args:
+    - "sleep 60"
+  readinessCheck: false
+
+image:
+  repository: quay.io/redhat-github-actions/runner
+  tag: latest

--- a/charts/github-actions-runner/templates/_helpers.tpl
+++ b/charts/github-actions-runner/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "github-actions-runner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "github-actions-runner.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "github-actions-runner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "github-actions-runner.labels" -}}
+helm.sh/chart: {{ include "github-actions-runner.chart" . }}
+{{ include "github-actions-runner.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "github-actions-runner.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "github-actions-runner.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "github-actions-runner.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "github-actions-runner.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/github-actions-runner/templates/configmap.yaml
+++ b/charts/github-actions-runner/templates/configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.deployment.name }}
+  {{- with .Values.configMap.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "github-actions-runner.labels" . | nindent 4 }}
+    {{- with .Values.configMap.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  {{- range $k, $v := .Values.configMap.data }}
+  {{ $k | quote }}: {{ $v | quote }}
+  {{- end }}

--- a/charts/github-actions-runner/templates/deployment.yaml
+++ b/charts/github-actions-runner/templates/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.deployment.name }}
+  {{- with .Values.deployment.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "github-actions-runner.labels" . | nindent 4 }}
+    {{- with .Values.deployment.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "github-actions-runner.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.pod.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "github-actions-runner.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Values.deployment.name }}
+          {{- with .Values.deployment.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.deployment.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}        
+          envFrom:
+            - configMapRef:
+                name: {{ .Values.deployment.name }}
+          {{- if .Values.secrets.enabled }}
+            - secretRef:
+                name: {{ .Values.deployment.name }}
+          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.deployment.readinessProbe }}
+          readinessProbe:
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 1
+            exec:
+              command:
+                - pgrep
+                - Runner.Listener
+          {{- end }}
+          {{- with .Values.deployment.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Values.deployment.serviceAccount.name }}
+      securityContext:
+        runAsNonRoot: true

--- a/charts/github-actions-runner/values.yaml
+++ b/charts/github-actions-runner/values.yaml
@@ -1,0 +1,50 @@
+# Default values for github-actions-runner.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+configMap:
+  annotations: {}
+  data:
+    EPHEMERAL: true
+    GITHUB_DOMAIN: ""
+    GITHUB_OWNER: mozilla
+    GITHUB_REPOSITORY: ""
+    RUNNER_GROUP: ""
+    RUNNER_LABELS: ubuntu,default
+  labels: {}
+
+deployment:
+  annotations: {}
+  args: []
+  command: []
+  labels: {}
+  name: gha-runner
+  readinessCheck: true
+  replicaCount: 1
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+  serviceAccount:
+    name: default
+
+image:
+  pullPolicy: IfNotPresent
+  repository: us-west1-docker.pkg.dev/moz-fx-platform-mgmt-global/gha-runners/default
+  tag: v0.0.1
+
+imagePullSecrets: []
+
+pod:
+  annotations: {}
+
+secrets:
+  enabled: false
+  # GITHUB_APP_ID: githubappid
+  # GITHUB_APP_INSTALL_ID: installID
+  # GITHUB_APP_PEM: PEM
+  # GITHUB_PAT: PAT
+  # RUNNER_TOKEN: token


### PR DESCRIPTION
Jira: https://mozilla-hub.atlassian.net/browse/OPST-164

What this PR does:
* adds start of a helm chart for GitHub Actions self-hosted runners

Not included:
* mainly setting up now for use in our global terraform atlantis deployments.