### PR TITLE
make securitycontext configurable

### DIFF
--- a/charts/github-actions-runner/Chart.yaml
+++ b/charts/github-actions-runner/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/github-actions-runner/templates/deployment.yaml
+++ b/charts/github-actions-runner/templates/deployment.yaml
@@ -63,5 +63,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Values.deployment.serviceAccount.name }}
+      {{- with .Values.deployment.securityContext }}
       securityContext:
-        runAsNonRoot: true
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/github-actions-runner/values.yaml
+++ b/charts/github-actions-runner/values.yaml
@@ -28,6 +28,8 @@ deployment:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  securityContext:
+    runAsNonRoot: true
   serviceAccount:
     name: default
 


### PR DESCRIPTION
See #128 

This PR just makes the deployment's SecurityContext configuration configurable outside of the helm chart templates.