### PR TITLE
chore(helm): Updates

### DIFF
--- a/charts/ctms/Chart.yaml
+++ b/charts/ctms/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Mozilla's CTMS-API app
 
 type: application
 
-version: 0.0.17
+version: 0.0.18

--- a/charts/ctms/templates/ingress.yaml
+++ b/charts/ctms/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "ctms.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/charts/fluentd-papertrail/Chart.yaml
+++ b/charts/fluentd-papertrail/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: fluentd-papertrail
 description: A Helm chart to deploy fluentd to send to papertrail
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "1.3"
 
 keywords:

--- a/charts/fluentd-papertrail/Chart.yaml
+++ b/charts/fluentd-papertrail/Chart.yaml
@@ -3,7 +3,7 @@ name: fluentd-papertrail
 description: A Helm chart to deploy fluentd to send to papertrail
 type: application
 version: 0.2.1
-appVersion: "1.2"
+appVersion: "1.3"
 
 keywords:
   - fluentd

--- a/charts/fluentd-papertrail/templates/daemonsets.yaml
+++ b/charts/fluentd-papertrail/templates/daemonsets.yaml
@@ -47,6 +47,8 @@ spec:
             {{- end }}
             - name: FLUENT_HOSTNAME
               value: {{ template "fluentd-papertrail.clusterName" . }}
+            - name: FLUENT_UID
+              value: "0"
             - name: K8S_NODE_NAME
               valueFrom:
                 fieldRef:

--- a/charts/fluentd-papertrail/values.yaml
+++ b/charts/fluentd-papertrail/values.yaml
@@ -6,8 +6,8 @@ fullnameOverride: ""
 clusterName: ""
 
 image:
-  repository: quay.io/solarwinds/fluentd-kubernetes
-  tag: v1.2-debian-papertrail-0.2.7-bugfix
+  repository: fluent/fluentd-kubernetes-daemonset
+  tag: papertrail
   pullPolicy: IfNotPresent
 
 updateStrategy:


### PR DESCRIPTION
- Fluent has moved images to Dockerhub. They are no longer publishing "Papertrail" versions but this gets us a much newer release non the less. The UID change is to give the pod access to tail the logs, without that it was failing.
- Ingress beta1 migrated to v1 as of 1.19