### PR TITLE
feature(external-secrets): Migrate to new external-secrets

### DIFF
--- a/charts/pastebin/Chart.yaml
+++ b/charts/pastebin/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: pastebin
 description: A Helm chart for the Mozilla Pastebin (dpaste) application
 type: application
-version: 0.1.5
+version: 0.2.0
 
 keywords:
   - Mozilla

--- a/charts/pastebin/templates/secrets.yaml
+++ b/charts/pastebin/templates/secrets.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.externalSecrets.enabled -}}
-apiVersion: kubernetes-client.io/v1
+apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
   name: {{ .Values.externalSecrets.name }}
@@ -13,11 +13,15 @@ metadata:
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  backendType: secretsManager
   data:
     {{- with .Values.externalSecrets.secrets }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: {{ .Values.externalSecrets.store }}
+  target:
+    name: {{ .Values.externalSecrets.target }} 
   template:
     metadata:
       {{- with .Values.externalSecrets.annotations }}

--- a/charts/pastebin/values.yaml
+++ b/charts/pastebin/values.yaml
@@ -48,6 +48,8 @@ externalSecrets:
   # - key: /{env}/pastebin/envvar
   #   name: SESSION_KEY
   #   property: session_key
+  store: secretsmanager-secretstore
+  target: pastebin
 
 image:
   pullPolicy: Always


### PR DESCRIPTION
This migrates to new external-secrets operator from deprecated
external-secrets helm service.

This will need to contain a change in the
`k8s/releases/pastebin/pastebin.yaml` in order to complete the
migration.

I have a diff like the following queued up for the itse-stage environment. These changes should conform to the new (external-secrets-operator API)[https://external-secrets.io/v0.5.9/api-externalsecret/].

```diff
diff --git a/k8s/releases/pastebin/pastebin.yaml b/k8s/releases/pastebin/pastebin.yaml
index 61455f3..db6bded 100644
--- a/k8s/releases/pastebin/pastebin.yaml
+++ b/k8s/releases/pastebin/pastebin.yaml
@@ -28,21 +28,26 @@ spec:
       enabled: true
       name: pastebin
       secrets:
-      - key: /stage/pastebin/envvar
-        name: DB_HOST
-        property: database_host
-      - key: /stage/pastebin/envvar
-        name: DB_NAME
-        property: database_name
-      - key: /stage/pastebin/envvar
-        name: DB_PASS
-        property: database_password
-      - key: /stage/pastebin/envvar
-        name: DB_USER
-        property: database_user
-      - key: /stage/pastebin/envvar
-        name: SESSION_KEY
-        property: session_key
+      - remoteRef:
+          key: /stage/pastebin/envvar
+          property: database_host
+        secretKey: DB_HOST
+      - remoteRef:
+          key: /stage/pastebin/envvar
+          property: database_name
+        secretKey: DB_NAME
+      - remoteRef:
+          key: /stage/pastebin/envvar
+          property: database_password
+        secretKey: DB_PASS
+      - remoteRef:
+          key: /stage/pastebin/envvar
+          property: database_user
+        secretKey: DB_USER
+      - remoteRef:
+          key: /stage/pastebin/envvar
+          property: session_key
+        secretKey: SESSION_KEY
     image:
       pullPolicy: Always
       repository: 783633885093.dkr.ecr.us-west-2.amazonaws.com/pastebin
```

In addition, I have used the kes-to-eso tool to migrate the secrets and create the new external-secrets-operator in the staging cluster.